### PR TITLE
ci: Set dependabot strategy for uv to widen

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,6 +3,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     target-branch: "dev"
+    versioning-strategy: "widen"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
The dependant strategy is currently very aggressive, risking breaking dependants. This PR makes it more permissive, giving more options to dependants.