### PR TITLE
ci: Set the versioning policy for dependabot to increase-if-neccessary for bluebird-dt

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "uv"
     directory: "/"
     target-branch: "dev"
-    versioning-strategy: "widen"
+    versioning-strategy: "increase-if-necessary"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
UV does not support a "widen" dependency strategy for dependabot, therefore this pull request suggests migrating to "increase-if-neccessary" which seems to be supported.