### PR TITLE
Make BluebirdATC a regular package rather than namespace package

### DIFF
--- a/bluebird-dt/bluebird_dt/__init__.py
+++ b/bluebird-dt/bluebird_dt/__init__.py
@@ -1,0 +1,1 @@
+"""Bluebird digital twin package."""


### PR DESCRIPTION
Added an __init__.py file at the top level of bluebird_dt to make package/resource lookup more stable. 

This has been done to resolve an issue seen in dependents when using a locally cloned instance of BluebirdATC. A dependent was attempting to resolve resource paths through .venv/site-packages instead of the local source tree.  This worked when pulling the BluebirdATC dependency direct from Github but not when pointing at a local clone.

In fact the issue is probably caused by flipping from one to the other, prior to this PR uv might have tried to mix and match the leftover bluebird_dt site package within .venv with the local clone (hence why we didn't see this before in BluebirdDT - we weren't switching between the two methods).