### PR TITLE
Add simple racetrack hold clearance

### DIFF
--- a/bluebird-dt/bluebird_dt/core/__init__.py
+++ b/bluebird-dt/bluebird_dt/core/__init__.py
@@ -1,4 +1,10 @@
-from bluebird_dt.core.action import Action, ClearanceAndResponse, HoldParameters
+from bluebird_dt.core.action import (
+    Action,
+    ClearanceAndResponse,
+    HoldAtFixParameters,
+    HoldAtLocationParameters,
+    HoldParameters,
+)
 from bluebird_dt.core.aircraft import Aircraft, FlightState, Instructions
 from bluebird_dt.core.airspace import Airspace
 from bluebird_dt.core.airway import Airway, AirwayLeg
@@ -29,6 +35,8 @@ __all__ = [
     "Fixes",
     "FlightPlan",
     "FlightState",
+    "HoldAtFixParameters",
+    "HoldAtLocationParameters",
     "HoldParameters",
     "Instructions",
     "Pilot",

--- a/bluebird-dt/bluebird_dt/core/__init__.py
+++ b/bluebird-dt/bluebird_dt/core/__init__.py
@@ -1,4 +1,4 @@
-from bluebird_dt.core.action import Action, ClearanceAndResponse
+from bluebird_dt.core.action import Action, ClearanceAndResponse, HoldParameters
 from bluebird_dt.core.aircraft import Aircraft, FlightState, Instructions
 from bluebird_dt.core.airspace import Airspace
 from bluebird_dt.core.airway import Airway, AirwayLeg
@@ -29,6 +29,7 @@ __all__ = [
     "Fixes",
     "FlightPlan",
     "FlightState",
+    "HoldParameters",
     "Instructions",
     "Pilot",
     "Pos2D",

--- a/bluebird-dt/bluebird_dt/core/__init__.py
+++ b/bluebird-dt/bluebird_dt/core/__init__.py
@@ -4,6 +4,7 @@ from bluebird_dt.core.action import (
     HoldAtFixParameters,
     HoldAtLocationParameters,
     HoldParameters,
+    parse_hold_parameters,
 )
 from bluebird_dt.core.aircraft import Aircraft, FlightState, Instructions
 from bluebird_dt.core.airspace import Airspace
@@ -49,4 +50,5 @@ __all__ = [
     "Volume",
     "WindField",
     "WindVector",
+    "parse_hold_parameters",
 ]

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -337,8 +337,9 @@ class Action(Comparison):
         if ">" in value:
             value = value.split(">")
 
-        # Hold parameters and change_* actions use JSON representations.
-        if kind == "hold_at_location" or "change" in kind:
+        # change_* actions use JSON representations. Hold parameters are
+        # validated from their JSON representation by the value setter.
+        if "change" in kind:
             value = json.loads(value)
 
         sector = None if sector == "all" or sector is None else sector.split(",")

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -6,8 +6,8 @@ import re
 import typing
 
 import numpy as np
-from pydantic import BaseModel, Field, model_validator
-from typing_extensions import Self, override
+from pydantic import BaseModel, Field, TypeAdapter
+from typing_extensions import override
 
 from bluebird_dt.mixin import Comparison
 from bluebird_dt.utility.supported_actions import SUPPORTED_ACTIONS
@@ -18,35 +18,46 @@ class ClearanceAndResponse(BaseModel):
     pilot_response: str | None
 
 
-class HoldParameters(BaseModel):
-    """Parameters for a racetrack hold at a named fix or latitude/longitude."""
+class HoldParametersBase(BaseModel):
+    """Parameters common to all racetrack hold targets."""
 
-    fix: str | None = Field(default=None, min_length=1)
-    location: tuple[
-        typing.Annotated[float, Field(ge=-90.0, le=90.0)],
-        typing.Annotated[float, Field(ge=-180.0, le=180.0)],
-    ] | None = None
     outbound_time: float = Field(default=90.0, gt=0.0)
     turn_direction: typing.Literal["left", "right"] = "right"
-
-    @model_validator(mode="after")
-    def validate_target(self) -> Self:
-        """Require exactly one holding target."""
-        if (self.fix is None) == (self.location is None):
-            raise ValueError("Exactly one of fix or location must be specified")
-        return self
-
-    @property
-    def location_label(self) -> str:
-        """Return a compact label for displays and clearances."""
-        if self.fix is not None:
-            return self.fix
-        assert self.location is not None
-        return f"{self.location[0]:g}, {self.location[1]:g}"
 
     def __str__(self) -> str:
         """Return the canonical representation used in clearance logs."""
         return self.model_dump_json()
+
+
+class HoldAtFixParameters(HoldParametersBase):
+    """Parameters for a racetrack hold at a named fix."""
+
+    fix: str = Field(min_length=1)
+    location: None = None
+
+    @property
+    def location_label(self) -> str:
+        """Return a compact label for displays and clearances."""
+        return self.fix
+
+
+class HoldAtLocationParameters(HoldParametersBase):
+    """Parameters for a racetrack hold at a latitude/longitude."""
+
+    fix: None = None
+    location: tuple[
+        typing.Annotated[float, Field(ge=-90.0, le=90.0)],
+        typing.Annotated[float, Field(ge=-180.0, le=180.0)],
+    ]
+
+    @property
+    def location_label(self) -> str:
+        """Return a compact label for displays and clearances."""
+        return f"{self.location[0]:g}, {self.location[1]:g}"
+
+
+HoldParameters: typing.TypeAlias = HoldAtFixParameters | HoldAtLocationParameters
+_HOLD_PARAMETERS_ADAPTER = TypeAdapter(HoldParameters)
 
 
 class Action(Comparison):
@@ -207,9 +218,9 @@ class Action(Comparison):
 
         if self.kind == "route_direct_to,hold_at_location":
             if isinstance(value, str):
-                self._value = HoldParameters.model_validate_json(value)
+                self._value = _HOLD_PARAMETERS_ADAPTER.validate_json(value)
             else:
-                self._value = HoldParameters.model_validate(value)
+                self._value = _HOLD_PARAMETERS_ADAPTER.validate_python(value)
         elif "level_by_fix" in self.kind:
             # first, check if it is a string (from the clearance df) and convert it back to a tuple.
             # the string should be of the form "(int/float, 'str')"

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -6,8 +6,8 @@ import re
 import typing
 
 import numpy as np
-from pydantic import BaseModel, Field
-from typing_extensions import override
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import Self, override
 
 from bluebird_dt.mixin import Comparison
 from bluebird_dt.utility.supported_actions import SUPPORTED_ACTIONS
@@ -19,11 +19,30 @@ class ClearanceAndResponse(BaseModel):
 
 
 class HoldParameters(BaseModel):
-    """Parameters for a racetrack hold at a named fix."""
+    """Parameters for a racetrack hold at a named fix or latitude/longitude."""
 
-    fix: str = Field(min_length=1)
+    fix: str | None = Field(default=None, min_length=1)
+    location: tuple[
+        typing.Annotated[float, Field(ge=-90.0, le=90.0)],
+        typing.Annotated[float, Field(ge=-180.0, le=180.0)],
+    ] | None = None
     outbound_time: float = Field(default=90.0, gt=0.0)
     turn_direction: typing.Literal["left", "right"] = "right"
+
+    @model_validator(mode="after")
+    def validate_target(self) -> Self:
+        """Require exactly one holding target."""
+        if (self.fix is None) == (self.location is None):
+            raise ValueError("Exactly one of fix or location must be specified")
+        return self
+
+    @property
+    def location_label(self) -> str:
+        """Return a compact label for displays and clearances."""
+        if self.fix is not None:
+            return self.fix
+        assert self.location is not None
+        return f"{self.location[0]:g}, {self.location[1]:g}"
 
     def __str__(self) -> str:
         """Return the canonical representation used in clearance logs."""
@@ -64,7 +83,7 @@ class Action(Comparison):
             Action type. All supported actions are found in the SUPPORTED_ACTIONS dictionary in the utility folder.
 
             - `route_direct_to`: go directly to named Fix(es) on Route (and set to route following)
-            - `hold_at_location`: fly to a named Fix and enter a repeating racetrack hold
+            - `hold_at_location`: fly to a named Fix or latitude/longitude and enter a repeating racetrack hold
             - `change_heading_to`: change heading to the specified degrees
             - `change_heading_to_by_direction`: change heading to the specified degrees by turning in a specific
             direction

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -60,6 +60,13 @@ HoldParameters: typing.TypeAlias = HoldAtFixParameters | HoldAtLocationParameter
 _HOLD_PARAMETERS_ADAPTER = TypeAdapter(HoldParameters)
 
 
+def parse_hold_parameters(value: object) -> HoldParameters:
+    """Parse hold parameters at an input or deserialization boundary."""
+    if isinstance(value, str):
+        return _HOLD_PARAMETERS_ADAPTER.validate_json(value)
+    return _HOLD_PARAMETERS_ADAPTER.validate_python(value)
+
+
 class Action(Comparison):
     """
     Fundamental unit of communication between Agent and Predictor.
@@ -77,7 +84,7 @@ class Action(Comparison):
         self,
         callsign: str,
         kind: str,
-        value: int | float | str | list[str] | tuple[int, str] | HoldParameters | dict[str, typing.Any] | None,
+        value: int | float | str | list[str] | tuple[int, str] | HoldParameters | None,
         agent: str | None = None,
         text_representation: ClearanceAndResponse | None = None,
         voice_representation: ClearanceAndResponse | None = None,
@@ -117,7 +124,7 @@ class Action(Comparison):
             Allowed values for each Action kind differs:
 
             - `route_direct_to`: str or list[str]
-            - `route_direct_to,hold_at_location`: HoldParameters or an equivalent dict
+            - `route_direct_to,hold_at_location`: HoldParameters
             - `change_heading_to`: int
             - `change_heading_to_by_direction`: tuple[int, Literal['left', 'right', 'shortest']]
             - `change_heading_by`: int
@@ -192,7 +199,7 @@ class Action(Comparison):
     @value.setter
     def value(
         self,
-        value: int | float | str | list[str] | tuple[int, str] | HoldParameters | dict[str, typing.Any] | None,
+        value: int | float | str | list[str] | tuple[int, str] | HoldParameters | None,
     ) -> None:
         """Set value and ensure correct type"""
         # raise error if value is None for action kinds that need a value
@@ -217,10 +224,12 @@ class Action(Comparison):
             raise Exception(f"Value cannot be None for action kind {self.kind}")
 
         if self.kind == "route_direct_to,hold_at_location":
-            if isinstance(value, str):
-                self._value = _HOLD_PARAMETERS_ADAPTER.validate_json(value)
-            else:
-                self._value = _HOLD_PARAMETERS_ADAPTER.validate_python(value)
+            if not isinstance(value, HoldParameters):
+                raise TypeError(
+                    "Action value must be HoldAtFixParameters or HoldAtLocationParameters "
+                    f"for {self.kind}. Got {type(value)}."
+                )
+            self._value = value
         elif "level_by_fix" in self.kind:
             # first, check if it is a string (from the clearance df) and convert it back to a tuple.
             # the string should be of the form "(int/float, 'str')"
@@ -349,9 +358,10 @@ class Action(Comparison):
         if ">" in value:
             value = value.split(">")
 
-        # change_* actions use JSON representations. Hold parameters are
-        # validated from their JSON representation by the value setter.
-        if "change" in kind:
+        # Actions with structured values are parsed at this deserialization boundary.
+        if kind == "route_direct_to,hold_at_location":
+            value = parse_hold_parameters(value)
+        elif "change" in kind:
             value = json.loads(value)
 
         sector = None if sector == "all" or sector is None else sector.split(",")
@@ -388,7 +398,9 @@ class Action(Comparison):
         kind = data["kind"]
         value = data["value"]
 
-        if "level_by_fix" in kind or kind == "change_heading_to_by_direction":
+        if kind == "route_direct_to,hold_at_location":
+            value = parse_hold_parameters(value)
+        elif "level_by_fix" in kind or kind == "change_heading_to_by_direction":
             value = tuple(value)
 
         voice_representation: str | None = data.get("voice_representation", None)

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -83,7 +83,8 @@ class Action(Comparison):
             Action type. All supported actions are found in the SUPPORTED_ACTIONS dictionary in the utility folder.
 
             - `route_direct_to`: go directly to named Fix(es) on Route (and set to route following)
-            - `hold_at_location`: fly to a named Fix or latitude/longitude and enter a repeating racetrack hold
+            - `route_direct_to,hold_at_location`: fly directly to a named Fix or latitude/longitude, then enter a
+                repeating racetrack hold
             - `change_heading_to`: change heading to the specified degrees
             - `change_heading_to_by_direction`: change heading to the specified degrees by turning in a specific
             direction
@@ -105,7 +106,7 @@ class Action(Comparison):
             Allowed values for each Action kind differs:
 
             - `route_direct_to`: str or list[str]
-            - `hold_at_location`: HoldParameters or an equivalent dict
+            - `route_direct_to,hold_at_location`: HoldParameters or an equivalent dict
             - `change_heading_to`: int
             - `change_heading_to_by_direction`: tuple[int, Literal['left', 'right', 'shortest']]
             - `change_heading_by`: int
@@ -186,7 +187,7 @@ class Action(Comparison):
         # raise error if value is None for action kinds that need a value
         if value is None and self.kind in [
             "route_direct_to",
-            "hold_at_location",
+            "route_direct_to,hold_at_location",
             "change_heading_to",
             "change_heading_by",
             "change_flight_level_to",
@@ -204,7 +205,7 @@ class Action(Comparison):
         ]:
             raise Exception(f"Value cannot be None for action kind {self.kind}")
 
-        if self.kind == "hold_at_location":
+        if self.kind == "route_direct_to,hold_at_location":
             if isinstance(value, str):
                 self._value = HoldParameters.model_validate_json(value)
             else:

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -554,7 +554,7 @@ class Action(Comparison):
             value = ">".join(self.value)
 
         elif isinstance(self.value, HoldParameters):
-            value = json.dumps(self.value.model_dump(), separators=(",", ":"))
+            value = self.value.model_dump_json()
 
         else:
             value = self.value

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -206,8 +206,9 @@ class Action(Comparison):
 
         if self.kind == "hold_at_location":
             if isinstance(value, str):
-                value = json.loads(value)
-            self._value = HoldParameters.model_validate(value)
+                self._value = HoldParameters.model_validate_json(value)
+            else:
+                self._value = HoldParameters.model_validate(value)
         elif "level_by_fix" in self.kind:
             # first, check if it is a string (from the clearance df) and convert it back to a tuple.
             # the string should be of the form "(int/float, 'str')"

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -6,7 +6,7 @@ import re
 import typing
 
 import numpy as np
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing_extensions import override
 
 from bluebird_dt.mixin import Comparison
@@ -18,6 +18,18 @@ class ClearanceAndResponse(BaseModel):
     pilot_response: str | None
 
 
+class HoldParameters(BaseModel):
+    """Parameters for a racetrack hold at a named fix."""
+
+    fix: str = Field(min_length=1)
+    outbound_time: float = Field(default=90.0, gt=0.0)
+    turn_direction: typing.Literal["left", "right"] = "right"
+
+    def __str__(self) -> str:
+        """Return the canonical representation used in clearance logs."""
+        return self.model_dump_json()
+
+
 class Action(Comparison):
     """
     Fundamental unit of communication between Agent and Predictor.
@@ -25,7 +37,7 @@ class Action(Comparison):
 
     callsign: str
     _kind: str
-    _value: int | float | str | list[str] | tuple[int, str] | None = None
+    _value: int | float | str | list[str] | tuple[int, str] | HoldParameters | None = None
     agent: str | None
     voice_representation: ClearanceAndResponse | None
     text_representation: ClearanceAndResponse | None
@@ -35,7 +47,7 @@ class Action(Comparison):
         self,
         callsign: str,
         kind: str,
-        value: int | float | str | list[str] | tuple[int, str] | None,
+        value: int | float | str | list[str] | tuple[int, str] | HoldParameters | dict[str, typing.Any] | None,
         agent: str | None = None,
         text_representation: ClearanceAndResponse | None = None,
         voice_representation: ClearanceAndResponse | None = None,
@@ -52,6 +64,7 @@ class Action(Comparison):
             Action type. All supported actions are found in the SUPPORTED_ACTIONS dictionary in the utility folder.
 
             - `route_direct_to`: go directly to named Fix(es) on Route (and set to route following)
+            - `hold_at_location`: fly to a named Fix and enter a repeating racetrack hold
             - `change_heading_to`: change heading to the specified degrees
             - `change_heading_to_by_direction`: change heading to the specified degrees by turning in a specific
             direction
@@ -73,6 +86,7 @@ class Action(Comparison):
             Allowed values for each Action kind differs:
 
             - `route_direct_to`: str or list[str]
+            - `hold_at_location`: HoldParameters or an equivalent dict
             - `change_heading_to`: int
             - `change_heading_to_by_direction`: tuple[int, Literal['left', 'right', 'shortest']]
             - `change_heading_by`: int
@@ -140,16 +154,20 @@ class Action(Comparison):
         self._kind = kind
 
     @property
-    def value(self) -> int | float | str | list[str] | tuple[int, str] | None:
+    def value(self) -> int | float | str | list[str] | tuple[int, str] | HoldParameters | None:
         """The Action value"""
         return self._value
 
     @value.setter
-    def value(self, value: int | float | str | list[str] | tuple[int, str] | None) -> None:
+    def value(
+        self,
+        value: int | float | str | list[str] | tuple[int, str] | HoldParameters | dict[str, typing.Any] | None,
+    ) -> None:
         """Set value and ensure correct type"""
         # raise error if value is None for action kinds that need a value
         if value is None and self.kind in [
             "route_direct_to",
+            "hold_at_location",
             "change_heading_to",
             "change_heading_by",
             "change_flight_level_to",
@@ -167,7 +185,11 @@ class Action(Comparison):
         ]:
             raise Exception(f"Value cannot be None for action kind {self.kind}")
 
-        if "level_by_fix" in self.kind:
+        if self.kind == "hold_at_location":
+            if isinstance(value, str):
+                value = json.loads(value)
+            self._value = HoldParameters.model_validate(value)
+        elif "level_by_fix" in self.kind:
             # first, check if it is a string (from the clearance df) and convert it back to a tuple.
             # the string should be of the form "(int/float, 'str')"
             if isinstance(value, str):
@@ -295,8 +317,8 @@ class Action(Comparison):
         if ">" in value:
             value = value.split(">")
 
-        # change_* actions take int or float as values, not str; json.loads will convert str to int or float as needed
-        if "change" in kind:
+        # Hold parameters and change_* actions use JSON representations.
+        if kind == "hold_at_location" or "change" in kind:
             value = json.loads(value)
 
         sector = None if sector == "all" or sector is None else sector.split(",")
@@ -365,7 +387,7 @@ class Action(Comparison):
         return {
             "callsign": self.callsign,
             "kind": self.kind,
-            "value": self.value,
+            "value": self.value.model_dump() if isinstance(self.value, HoldParameters) else self.value,
             "agent": self.agent,
             "text_representation": (
                 None if self.text_representation is None else self.text_representation.model_dump()
@@ -485,6 +507,9 @@ class Action(Comparison):
 
         elif isinstance(self.value, list):
             value = ">".join(self.value)
+
+        elif isinstance(self.value, HoldParameters):
+            value = json.dumps(self.value.model_dump(), separators=(",", ":"))
 
         else:
             value = self.value

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -432,7 +432,7 @@ class Action(Comparison):
         return {
             "callsign": self.callsign,
             "kind": self.kind,
-            "value": self.value.model_dump() if isinstance(self.value, HoldParameters) else self.value,
+            "value": self.value.model_dump() if isinstance(self.value, BaseModel) else self.value,
             "agent": self.agent,
             "text_representation": (
                 None if self.text_representation is None else self.text_representation.model_dump()

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -21,7 +21,7 @@ class ClearanceAndResponse(BaseModel):
 class HoldParametersBase(BaseModel):
     """Parameters common to all racetrack hold targets."""
 
-    outbound_time: float = Field(default=90.0, gt=0.0)
+    outbound_time_s: float = Field(default=90.0, gt=0.0)
     turn_direction: typing.Literal["left", "right"] = "right"
 
     def __str__(self) -> str:

--- a/bluebird-dt/bluebird_dt/core/pilot.py
+++ b/bluebird-dt/bluebird_dt/core/pilot.py
@@ -5,6 +5,7 @@ import typing
 from typing import TypedDict
 
 from bluebird_dt.core import Action
+from bluebird_dt.core.pos2d import Pos2D
 from bluebird_dt.logger import logger
 from bluebird_dt.utility.convert import (
     timestamp_to_string,
@@ -218,7 +219,11 @@ class Pilot:
 
         aircraft = environment.aircraft[self.callsign]
 
-        if action.kind == "hold_at_location" and action.value.fix not in environment.airspace.fixes.places:
+        if (
+            action.kind == "hold_at_location"
+            and action.value.fix is not None
+            and action.value.fix not in environment.airspace.fixes.places
+        ):
             raise ValueError(f"Unknown holding fix: {action.value.fix}")
 
         # Any new lateral clearance replaces the active hold. A new hold creates
@@ -246,7 +251,11 @@ class Pilot:
 
         elif action.kind == "hold_at_location":
             hold = action.value
-            target_pos = environment.airspace.fixes.places[hold.fix]
+            if hold.fix is not None:
+                target_pos = environment.airspace.fixes.places[hold.fix]
+            else:
+                assert hold.location is not None
+                target_pos = Pos2D(*hold.location)
             aircraft.cleared_instructions.on_route = False
             aircraft.selected_instructions.on_route = False
             aircraft.cleared_instructions.heading = None
@@ -254,6 +263,7 @@ class Pilot:
             aircraft.heading_changing_to = aircraft.pos2d().bearing_to(target_pos)
             aircraft.predictor_params["hold"] = {
                 "fix": hold.fix,
+                "location": [target_pos.lat, target_pos.lon],
                 "outbound_time": hold.outbound_time,
                 "turn_direction": hold.turn_direction,
                 "phase": "direct_to_fix",

--- a/bluebird-dt/bluebird_dt/core/pilot.py
+++ b/bluebird-dt/bluebird_dt/core/pilot.py
@@ -215,6 +215,11 @@ class Pilot:
             Action issued to the Aircraft
         environment: Environment
             The simulation environment at the time step
+
+        Note
+        ----
+        Any new lateral clearance replaces an active hold. A new hold creates
+        fresh state after the old one has been discarded.
         """
 
         aircraft = environment.aircraft[self.callsign]

--- a/bluebird-dt/bluebird_dt/core/pilot.py
+++ b/bluebird-dt/bluebird_dt/core/pilot.py
@@ -220,7 +220,7 @@ class Pilot:
         aircraft = environment.aircraft[self.callsign]
 
         if (
-            action.kind == "hold_at_location"
+            action.kind == "route_direct_to,hold_at_location"
             and action.value.fix is not None
             and action.value.fix not in environment.airspace.fixes.places
         ):
@@ -249,7 +249,7 @@ class Pilot:
 
             aircraft.heading_changing_to = aircraft.selected_instructions.heading
 
-        elif action.kind == "hold_at_location":
+        elif action.kind == "route_direct_to,hold_at_location":
             hold = action.value
             if hold.fix is not None:
                 target_pos = environment.airspace.fixes.places[hold.fix]
@@ -266,7 +266,7 @@ class Pilot:
                 "location": [target_pos.lat, target_pos.lon],
                 "outbound_time": hold.outbound_time,
                 "turn_direction": hold.turn_direction,
-                "phase": "direct_to_fix",
+                "phase": "direct_to_location",
                 "phase_elapsed": 0.0,
                 "inbound_track": None,
             }

--- a/bluebird-dt/bluebird_dt/core/pilot.py
+++ b/bluebird-dt/bluebird_dt/core/pilot.py
@@ -273,6 +273,7 @@ class Pilot:
                 "turn_direction": hold.turn_direction,
                 "phase": "direct_to_location",
                 "phase_elapsed": 0.0,
+                # Runtime state set from the ground track on first arrival; it defines the racetrack axis.
                 "inbound_track": None,
             }
 

--- a/bluebird-dt/bluebird_dt/core/pilot.py
+++ b/bluebird-dt/bluebird_dt/core/pilot.py
@@ -218,6 +218,13 @@ class Pilot:
 
         aircraft = environment.aircraft[self.callsign]
 
+        if action.kind == "hold_at_location" and action.value.fix not in environment.airspace.fixes.places:
+            raise ValueError(f"Unknown holding fix: {action.value.fix}")
+
+        # Any new lateral clearance replaces the active hold. A new hold creates
+        # fresh state below after the old one has been discarded.
+        aircraft.predictor_params.pop("hold", None)
+
         if action.kind in ["change_heading_by", "change_heading_to", "change_heading_to_by_direction"]:
             match action.kind:
                 case "change_heading_by":
@@ -236,6 +243,23 @@ class Pilot:
             aircraft.selected_instructions.heading = heading % 360
 
             aircraft.heading_changing_to = aircraft.selected_instructions.heading
+
+        elif action.kind == "hold_at_location":
+            hold = action.value
+            target_pos = environment.airspace.fixes.places[hold.fix]
+            aircraft.cleared_instructions.on_route = False
+            aircraft.selected_instructions.on_route = False
+            aircraft.cleared_instructions.heading = None
+            aircraft.selected_instructions.heading = None
+            aircraft.heading_changing_to = aircraft.pos2d().bearing_to(target_pos)
+            aircraft.predictor_params["hold"] = {
+                "fix": hold.fix,
+                "outbound_time": hold.outbound_time,
+                "turn_direction": hold.turn_direction,
+                "phase": "direct_to_fix",
+                "phase_elapsed": 0.0,
+                "inbound_track": None,
+            }
 
         elif action.kind == "route_direct_to":
             # create a new current route that starts with fix(es) provided in action

--- a/bluebird-dt/bluebird_dt/core/pilot.py
+++ b/bluebird-dt/bluebird_dt/core/pilot.py
@@ -264,7 +264,7 @@ class Pilot:
             aircraft.predictor_params["hold"] = {
                 "fix": hold.fix,
                 "location": [target_pos.lat, target_pos.lon],
-                "outbound_time": hold.outbound_time,
+                "outbound_time_s": hold.outbound_time_s,
                 "turn_direction": hold.turn_direction,
                 "phase": "direct_to_location",
                 "phase_elapsed": 0.0,

--- a/bluebird-dt/bluebird_dt/events/event_handler.py
+++ b/bluebird-dt/bluebird_dt/events/event_handler.py
@@ -21,6 +21,7 @@ from bluebird_dt.core import (
     Instructions,
     Route,
     WindField,
+    parse_hold_parameters,
 )
 from bluebird_dt.events.event_dtypes import EventDtypes
 from bluebird_dt.logger import logger
@@ -1854,11 +1855,17 @@ def update_from_clearances(
         if row.kind == "route_direct_to" and aircraft.flight_plan is None:
             continue
 
+        # Parse structured values at the clearance-log boundary. Action itself
+        # only accepts the corresponding domain model.
+        value = row.value
+        if row.kind == "route_direct_to,hold_at_location":
+            value = parse_hold_parameters(value)
+
         # update the aircraft using the clearance
         action = Action(
             callsign,
             row.kind,
-            row.value,
+            value,
             agent=row.agent,
             text_representation=ClearanceAndResponse(
                 clearance=row.text_clearance, pilot_response=row.text_pilot_response

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -21,8 +21,9 @@ from bluebird_dt.utility.performance import get_aircraft_key_mapping
 # Default rate of turn (in degrees per second) - used for heading change turns (i.e. not route turns)
 DEFAULT_RATE_OF_TURN = 1.5
 
-# Holds are flown as standard-rate turns, independently of an aircraft's
-# configured rate for ordinary heading changes.
+# Assumption: Holds are flown as standard-rate turns, independently of an aircraft's
+# configured rate for ordinary heading changes.  According to ICAO 8168 section 2.1.2, all turns
+# shall be made at a bank angle of 25° or at a rate of 3° per second, whichever requires the lesser bank.
 HOLD_RATE_OF_TURN_s = 3.0
 
 # Threshold difference (in degrees) between requested heading and actual heading. Below this threshold

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -8,7 +8,7 @@ from typing import Literal
 import numpy as np
 
 from bluebird_dt.core import Aircraft, Fixes, Pos2D, Pos4D
-from bluebird_dt.core.wind import WindField
+from bluebird_dt.core.wind import WindField, WindVector
 from bluebird_dt.utility.constants import G_ACC
 from bluebird_dt.utility.convert import (
     KT_TO_MPS,
@@ -20,6 +20,10 @@ from bluebird_dt.utility.performance import get_aircraft_key_mapping
 
 # Default rate of turn (in degrees per second) - used for heading change turns (i.e. not route turns)
 DEFAULT_RATE_OF_TURN = 1.5
+
+# Holds are flown as standard-rate turns, independently of an aircraft's
+# configured rate for ordinary heading changes.
+HOLD_RATE_OF_TURN = 3.0
 
 # Threshold difference (in degrees) between requested heading and actual heading. Below this threshold
 # the heading is automatically updated, without an explicit use of a turn model.
@@ -290,6 +294,11 @@ class Predictor(ABC):
             Flag indicating whether to use turn model or just instantaneously update heading. Default is True.
         """
 
+        # A hold explicitly requires fixed-rate turns, even when a predictor was
+        # configured to make ordinary heading changes instantaneous.
+        if aircraft.predictor_params.get("hold") is not None:
+            use_turn_model = True
+
         if use_turn_model:
             self.update_position_with_turn_model(aircraft, time_evolve, wind_field)
 
@@ -316,6 +325,10 @@ class Predictor(ABC):
         )
 
         ground_speed, ground_track_angle = ground_speed_from_tas(horizontal_speed_kts, aircraft.heading, wind_vector)
+
+        hold = aircraft.predictor_params.get("hold")
+        if hold is not None:
+            self.update_hold_guidance(aircraft, hold, ground_track_angle, horizontal_speed_kts, wind_vector)
 
         # If route-following, check if we need to increment the next_fix_index.
         if aircraft.on_route:
@@ -385,6 +398,8 @@ class Predictor(ABC):
             current_bearing = ground_track_angle
 
             rate_of_turn = aircraft.rate_of_turn if aircraft.rate_of_turn else DEFAULT_RATE_OF_TURN
+            if hold is not None and hold["phase"] in ["turn_outbound", "turn_inbound"]:
+                rate_of_turn = HOLD_RATE_OF_TURN
             # If have started a route turn, then continue the turn at same radius. So calculate the rate of turn
             # from ground speed and turn radius. This means that speed changes won't affect the turn radius.
             if aircraft.on_route and aircraft.predictor_params.get("turn_radius", None) is not None:
@@ -395,7 +410,9 @@ class Predictor(ABC):
             turn_direction: Literal["left", "right"] | None = None
 
             # If aircraft is flying a heading
-            if (
+            if hold is not None and hold["phase"] in ["turn_outbound", "turn_inbound"]:
+                turn_direction = hold["turn_direction"]
+            elif (
                 aircraft.cleared_instructions.lateral_action is not None
                 and aircraft.cleared_instructions.lateral_action.kind == "change_heading_to_by_direction"
                 and aircraft.cleared_instructions.lateral_action.value[1] != "shortest"
@@ -446,6 +463,81 @@ class Predictor(ABC):
 
         aircraft.lat = new_pos.lat
         aircraft.lon = new_pos.lon
+
+        if hold is not None and hold["phase"] == "outbound":
+            hold["phase_elapsed"] += time_evolve
+
+    def update_hold_guidance(
+        self,
+        aircraft: Aircraft,
+        hold: dict,
+        ground_track_angle: float,
+        horizontal_speed_kts: float,
+        wind_vector: WindVector | None,
+    ):
+        """Update lateral guidance for the current phase of a racetrack hold."""
+        if self.fixes is None:
+            raise ValueError("Cannot hold at a fix without predictor.fixes")
+
+        fix_pos = self.fixes.places[hold["fix"]]
+        phase = hold["phase"]
+        entered_turn = False
+
+        if phase in ["direct_to_fix", "inbound"]:
+            distance_to_fix = aircraft.pos2d().distance(fix_pos)
+            if distance_to_fix <= self.fix_proximity_threshold:
+                if hold["inbound_track"] is None:
+                    hold["inbound_track"] = ground_track_angle
+                hold["phase"] = "turn_outbound"
+                hold["phase_elapsed"] = 0.0
+                phase = "turn_outbound"
+                entered_turn = True
+            else:
+                target_track = aircraft.pos2d().bearing_to(fix_pos)
+                aircraft.heading_changing_to = heading_from_ground_track(
+                    target_track, horizontal_speed_kts, wind_vector
+                )
+                return
+
+        if phase == "turn_outbound":
+            target_track = (hold["inbound_track"] + 180.0) % 360.0
+            if aircraft.heading_changing_to is None and not entered_turn:
+                hold["phase"] = "outbound"
+                hold["phase_elapsed"] = 0.0
+                aircraft.heading = heading_from_ground_track(target_track, horizontal_speed_kts, wind_vector)
+            else:
+                aircraft.heading_changing_to = heading_from_ground_track(
+                    target_track, horizontal_speed_kts, wind_vector
+                )
+            return
+
+        if phase == "outbound":
+            target_track = (hold["inbound_track"] + 180.0) % 360.0
+            if hold["phase_elapsed"] >= hold["outbound_time"]:
+                hold["phase"] = "turn_inbound"
+                hold["phase_elapsed"] = 0.0
+                target_track = hold["inbound_track"]
+                aircraft.heading_changing_to = heading_from_ground_track(
+                    target_track, horizontal_speed_kts, wind_vector
+                )
+            else:
+                aircraft.heading = heading_from_ground_track(target_track, horizontal_speed_kts, wind_vector)
+                aircraft.heading_changing_to = None
+            return
+
+        if phase == "turn_inbound":
+            target_track = hold["inbound_track"]
+            if aircraft.heading_changing_to is None:
+                hold["phase"] = "inbound"
+                aircraft.heading = heading_from_ground_track(target_track, horizontal_speed_kts, wind_vector)
+            else:
+                aircraft.heading_changing_to = heading_from_ground_track(
+                    target_track, horizontal_speed_kts, wind_vector
+                )
+            return
+
+        if phase != "inbound":
+            raise ValueError(f"Unrecognised hold phase: {phase}")
 
     def update_position_without_turn_model(self, aircraft: Aircraft, time_evolve: float, wind_field: WindField | None):
         """

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -480,16 +480,16 @@ class Predictor(ABC):
         if location is None:
             if self.fixes is None or hold.get("fix") is None:
                 raise ValueError("Hold state has no resolvable location")
-            fix_pos = self.fixes.places[hold["fix"]]
-            hold["location"] = [fix_pos.lat, fix_pos.lon]
+            target_pos = self.fixes.places[hold["fix"]]
+            hold["location"] = [target_pos.lat, target_pos.lon]
         else:
-            fix_pos = Pos2D(*location)
+            target_pos = Pos2D(*location)
         phase = hold["phase"]
         entered_turn = False
 
-        if phase in ["direct_to_fix", "inbound"]:
-            distance_to_fix = aircraft.pos2d().distance(fix_pos)
-            if distance_to_fix <= self.fix_proximity_threshold:
+        if phase in ["direct_to_location", "inbound"]:
+            distance_to_location = aircraft.pos2d().distance(target_pos)
+            if distance_to_location <= self.fix_proximity_threshold:
                 if hold["inbound_track"] is None:
                     hold["inbound_track"] = ground_track_angle
                 hold["phase"] = "turn_outbound"
@@ -497,7 +497,7 @@ class Predictor(ABC):
                 phase = "turn_outbound"
                 entered_turn = True
             else:
-                target_track = aircraft.pos2d().bearing_to(fix_pos)
+                target_track = aircraft.pos2d().bearing_to(target_pos)
                 aircraft.heading_changing_to = heading_from_ground_track(
                     target_track, horizontal_speed_kts, wind_vector
                 )

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -476,10 +476,14 @@ class Predictor(ABC):
         wind_vector: WindVector | None,
     ):
         """Update lateral guidance for the current phase of a racetrack hold."""
-        if self.fixes is None:
-            raise ValueError("Cannot hold at a fix without predictor.fixes")
-
-        fix_pos = self.fixes.places[hold["fix"]]
+        location = hold.get("location")
+        if location is None:
+            if self.fixes is None or hold.get("fix") is None:
+                raise ValueError("Hold state has no resolvable location")
+            fix_pos = self.fixes.places[hold["fix"]]
+            hold["location"] = [fix_pos.lat, fix_pos.lon]
+        else:
+            fix_pos = Pos2D(*location)
         phase = hold["phase"]
         entered_turn = False
 

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -294,8 +294,8 @@ class Predictor(ABC):
             Flag indicating whether to use turn model or just instantaneously update heading. Default is True.
         """
 
-        # A hold explicitly requires fixed-rate turns, even when a predictor was
-        # configured to make ordinary heading changes instantaneous.
+        # This implementation of a hold explicitly requires fixed-rate turns,
+        # even when a predictor was configured to make ordinary heading changes instantaneous.
         if aircraft.predictor_params.get("hold") is not None:
             use_turn_model = True
 

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -23,7 +23,7 @@ DEFAULT_RATE_OF_TURN = 1.5
 
 # Holds are flown as standard-rate turns, independently of an aircraft's
 # configured rate for ordinary heading changes.
-HOLD_RATE_OF_TURN = 3.0
+HOLD_RATE_OF_TURN_s = 3.0
 
 # Threshold difference (in degrees) between requested heading and actual heading. Below this threshold
 # the heading is automatically updated, without an explicit use of a turn model.
@@ -399,7 +399,7 @@ class Predictor(ABC):
 
             rate_of_turn = aircraft.rate_of_turn if aircraft.rate_of_turn else DEFAULT_RATE_OF_TURN
             if hold is not None and hold["phase"] in ["turn_outbound", "turn_inbound"]:
-                rate_of_turn = HOLD_RATE_OF_TURN
+                rate_of_turn = HOLD_RATE_OF_TURN_s
             # If have started a route turn, then continue the turn at same radius. So calculate the rate of turn
             # from ground speed and turn radius. This means that speed changes won't affect the turn radius.
             if aircraft.on_route and aircraft.predictor_params.get("turn_radius", None) is not None:
@@ -517,7 +517,7 @@ class Predictor(ABC):
 
         if phase == "outbound":
             target_track = (hold["inbound_track"] + 180.0) % 360.0
-            if hold["phase_elapsed"] >= hold["outbound_time"]:
+            if hold["phase_elapsed"] >= hold["outbound_time_s"]:
                 hold["phase"] = "turn_inbound"
                 hold["phase_elapsed"] = 0.0
                 target_track = hold["inbound_track"]

--- a/bluebird-dt/bluebird_dt/simulator/simulator.py
+++ b/bluebird-dt/bluebird_dt/simulator/simulator.py
@@ -156,13 +156,12 @@ class Simulator:
         """
         The location of the base logfile directory can be overridden by derived classes.
         """
-        log_dir = os.path.join(LOG_DIR, self.log_filename)
-        os.makedirs(log_dir, exist_ok=True)
-        log_file = os.path.join(log_dir, self.log_filename + ".log")
-        self.logging_file_handler = logging.FileHandler(log_file)
+        os.makedirs(os.path.join(LOG_DIR, "runtime_logs"), exist_ok=True)
+        self.logging_file_handler = logging.FileHandler(
+            os.path.join(LOG_DIR, "runtime_logs", self.log_filename + ".log")
+        )
         self.logging_file_handler.setFormatter(CustomFormatter())
         logger.addHandler(self.logging_file_handler)
-        logger.info(f"Saving logs to {log_dir}")
 
     @classmethod
     def from_category(

--- a/bluebird-dt/bluebird_dt/utility/clearance.py
+++ b/bluebird-dt/bluebird_dt/utility/clearance.py
@@ -767,7 +767,7 @@ def text_phraseology(action: Action, environment: Environment) -> ClearanceAndRe
 
         case "route_direct_to,hold_at_location":
             assert isinstance(value, HoldParameters)
-            minutes = f"{value.outbound_time / 60.0:g}"
+            minutes = f"{value.outbound_time_s / 60.0:g}"
             location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"
             clearance_parts.extend(
                 ["hold at", location, value.turn_direction, "hand", "outbound time", minutes, "minutes"]
@@ -1009,7 +1009,7 @@ def voice_phraseology(action: Action, environment: Environment) -> ClearanceAndR
 
         case "route_direct_to,hold_at_location":
             assert isinstance(value, HoldParameters)
-            minutes = f"{value.outbound_time / 60.0:g}"
+            minutes = f"{value.outbound_time_s / 60.0:g}"
             location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"
             clearance_parts.extend(
                 ["hold at", location, value.turn_direction, "hand", "outbound time", minutes, "minutes"]

--- a/bluebird-dt/bluebird_dt/utility/clearance.py
+++ b/bluebird-dt/bluebird_dt/utility/clearance.py
@@ -9,6 +9,7 @@ from bluebird_dt.core import (
     ClearanceAndResponse,
     Environment,
     FlightPlan,
+    HoldParameters,
     Route,
 )
 from bluebird_dt.logger import logger
@@ -764,6 +765,13 @@ def text_phraseology(action: Action, environment: Environment) -> ClearanceAndRe
             else:
                 clearance_parts.extend(["resume own navigation", str(fix)])
 
+        case "hold_at_location":
+            assert isinstance(value, HoldParameters)
+            minutes = f"{value.outbound_time / 60.0:g}"
+            clearance_parts.extend(
+                ["hold at", value.fix, value.turn_direction, "hand", "outbound time", minutes, "minutes"]
+            )
+
         case "change_cas_to":
             clearance_parts.extend(["fly speed", str(value), "knots"])
 
@@ -997,6 +1005,13 @@ def voice_phraseology(action: Action, environment: Environment) -> ClearanceAndR
                 clearance_parts.extend(["route direct", fix])
             else:
                 clearance_parts.extend(["resume own navigation", str(fix)])
+
+        case "hold_at_location":
+            assert isinstance(value, HoldParameters)
+            minutes = f"{value.outbound_time / 60.0:g}"
+            clearance_parts.extend(
+                ["hold at", value.fix, value.turn_direction, "hand", "outbound time", minutes, "minutes"]
+            )
 
         case "change_cas_to":
             clearance_parts.extend(["speed", spell_phonetically(str(value)), "knots"])

--- a/bluebird-dt/bluebird_dt/utility/clearance.py
+++ b/bluebird-dt/bluebird_dt/utility/clearance.py
@@ -768,8 +768,9 @@ def text_phraseology(action: Action, environment: Environment) -> ClearanceAndRe
         case "hold_at_location":
             assert isinstance(value, HoldParameters)
             minutes = f"{value.outbound_time / 60.0:g}"
+            location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"
             clearance_parts.extend(
-                ["hold at", value.fix, value.turn_direction, "hand", "outbound time", minutes, "minutes"]
+                ["hold at", location, value.turn_direction, "hand", "outbound time", minutes, "minutes"]
             )
 
         case "change_cas_to":
@@ -1009,8 +1010,9 @@ def voice_phraseology(action: Action, environment: Environment) -> ClearanceAndR
         case "hold_at_location":
             assert isinstance(value, HoldParameters)
             minutes = f"{value.outbound_time / 60.0:g}"
+            location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"
             clearance_parts.extend(
-                ["hold at", value.fix, value.turn_direction, "hand", "outbound time", minutes, "minutes"]
+                ["hold at", location, value.turn_direction, "hand", "outbound time", minutes, "minutes"]
             )
 
         case "change_cas_to":

--- a/bluebird-dt/bluebird_dt/utility/clearance.py
+++ b/bluebird-dt/bluebird_dt/utility/clearance.py
@@ -765,7 +765,7 @@ def text_phraseology(action: Action, environment: Environment) -> ClearanceAndRe
             else:
                 clearance_parts.extend(["resume own navigation", str(fix)])
 
-        case "hold_at_location":
+        case "route_direct_to,hold_at_location":
             assert isinstance(value, HoldParameters)
             minutes = f"{value.outbound_time / 60.0:g}"
             location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"
@@ -1007,7 +1007,7 @@ def voice_phraseology(action: Action, environment: Environment) -> ClearanceAndR
             else:
                 clearance_parts.extend(["resume own navigation", str(fix)])
 
-        case "hold_at_location":
+        case "route_direct_to,hold_at_location":
             assert isinstance(value, HoldParameters)
             minutes = f"{value.outbound_time / 60.0:g}"
             location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"

--- a/bluebird-dt/bluebird_dt/utility/supported_actions.py
+++ b/bluebird-dt/bluebird_dt/utility/supported_actions.py
@@ -9,6 +9,7 @@ SUPPORTED_ACTIONS = {
     "vertical_speed": ["change_vertical_speed_to"],
     "lateral": [
         "route_direct_to",
+        "hold_at_location",
         "change_heading_to",
         "change_heading_to_by_direction",
         "change_heading_by",

--- a/bluebird-dt/bluebird_dt/utility/supported_actions.py
+++ b/bluebird-dt/bluebird_dt/utility/supported_actions.py
@@ -9,7 +9,7 @@ SUPPORTED_ACTIONS = {
     "vertical_speed": ["change_vertical_speed_to"],
     "lateral": [
         "route_direct_to",
-        "hold_at_location",
+        "route_direct_to,hold_at_location",
         "change_heading_to",
         "change_heading_to_by_direction",
         "change_heading_by",

--- a/bluebird-dt/tests/unit/core/conftest.py
+++ b/bluebird-dt/tests/unit/core/conftest.py
@@ -18,6 +18,7 @@ from bluebird_dt.core import (
     Environment,
     Fixes,
     FlightPlan,
+    HoldParameters,
     Pilot,
     Pos2D,
     Pos3D,
@@ -514,6 +515,8 @@ def make_action(kind: str) -> Action:
     value = None
     if kind == "route_direct_to":
         value = random.choice([make_random_fix_name(), [make_random_fix_name()]])
+    if kind == "hold_at_location":
+        value = HoldParameters(fix=make_random_fix_name())
     if kind == "change_heading_to":
         value = make_random_heading()
     if kind == "change_heading_to_by_direction":

--- a/bluebird-dt/tests/unit/core/conftest.py
+++ b/bluebird-dt/tests/unit/core/conftest.py
@@ -515,7 +515,7 @@ def make_action(kind: str) -> Action:
     value = None
     if kind == "route_direct_to":
         value = random.choice([make_random_fix_name(), [make_random_fix_name()]])
-    if kind == "hold_at_location":
+    if kind == "route_direct_to,hold_at_location":
         value = HoldParameters(fix=make_random_fix_name())
     if kind == "change_heading_to":
         value = make_random_heading()

--- a/bluebird-dt/tests/unit/core/conftest.py
+++ b/bluebird-dt/tests/unit/core/conftest.py
@@ -18,7 +18,7 @@ from bluebird_dt.core import (
     Environment,
     Fixes,
     FlightPlan,
-    HoldParameters,
+    HoldAtFixParameters,
     Pilot,
     Pos2D,
     Pos3D,
@@ -516,7 +516,7 @@ def make_action(kind: str) -> Action:
     if kind == "route_direct_to":
         value = random.choice([make_random_fix_name(), [make_random_fix_name()]])
     if kind == "route_direct_to,hold_at_location":
-        value = HoldParameters(fix=make_random_fix_name())
+        value = HoldAtFixParameters(fix=make_random_fix_name())
     if kind == "change_heading_to":
         value = make_random_heading()
     if kind == "change_heading_to_by_direction":

--- a/bluebird-dt/tests/unit/core/test_action.py
+++ b/bluebird-dt/tests/unit/core/test_action.py
@@ -91,7 +91,7 @@ def test_hold_parameters_roundtrip():
     action = Action(
         callsign="AIR0",
         kind="route_direct_to,hold_at_location",
-        value={"fix": "FIX", "outbound_time": 60, "turn_direction": "left"},
+        value={"fix": "FIX", "outbound_time_s": 60, "turn_direction": "left"},
     )
 
     assert action == Action.from_json(action.to_json())
@@ -102,17 +102,17 @@ def test_hold_parameters_from_json_string():
     action = Action(
         callsign="AIR0",
         kind="route_direct_to,hold_at_location",
-        value='{"fix":"FIX","outbound_time":60,"turn_direction":"left"}',
+        value='{"fix":"FIX","outbound_time_s":60,"turn_direction":"left"}',
     )
 
-    assert action.value == HoldAtFixParameters(fix="FIX", outbound_time=60, turn_direction="left")
+    assert action.value == HoldAtFixParameters(fix="FIX", outbound_time_s=60, turn_direction="left")
 
 
 def test_coordinate_hold_parameters_roundtrip():
     action = Action(
         callsign="AIR0",
         kind="route_direct_to,hold_at_location",
-        value={"location": (50.716667, -3.533333), "outbound_time": 60},
+        value={"location": (50.716667, -3.533333), "outbound_time_s": 60},
     )
 
     assert action.value.location == (50.716667, -3.533333)
@@ -129,7 +129,7 @@ def test_coordinate_hold_parameters_roundtrip():
         {"fix": "FIX", "location": (50.0, -3.0)},
         {"location": (91.0, -3.0)},
         {"location": (50.0, -181.0)},
-        {"fix": "FIX", "outbound_time": 0},
+        {"fix": "FIX", "outbound_time_s": 0},
         {"fix": "FIX", "turn_direction": "straight"},
     ],
 )

--- a/bluebird-dt/tests/unit/core/test_action.py
+++ b/bluebird-dt/tests/unit/core/test_action.py
@@ -30,7 +30,7 @@ def test_init_exceptions_from_str():
     "kind, value",
     [
         ("route_direct_to", "FIX"),
-        ("hold_at_location", HoldParameters(fix="FIX")),
+        ("route_direct_to,hold_at_location", HoldParameters(fix="FIX")),
         ("change_heading_to", 120),
         ("change_heading_by", -10),
         ("change_flight_level_to", 250),
@@ -90,7 +90,7 @@ def test_from_str_with_sector():
 def test_hold_parameters_roundtrip():
     action = Action(
         callsign="AIR0",
-        kind="hold_at_location",
+        kind="route_direct_to,hold_at_location",
         value={"fix": "FIX", "outbound_time": 60, "turn_direction": "left"},
     )
 
@@ -101,7 +101,7 @@ def test_hold_parameters_roundtrip():
 def test_hold_parameters_from_json_string():
     action = Action(
         callsign="AIR0",
-        kind="hold_at_location",
+        kind="route_direct_to,hold_at_location",
         value='{"fix":"FIX","outbound_time":60,"turn_direction":"left"}',
     )
 
@@ -111,7 +111,7 @@ def test_hold_parameters_from_json_string():
 def test_coordinate_hold_parameters_roundtrip():
     action = Action(
         callsign="AIR0",
-        kind="hold_at_location",
+        kind="route_direct_to,hold_at_location",
         value={"location": (50.716667, -3.533333), "outbound_time": 60},
     )
 
@@ -135,7 +135,7 @@ def test_coordinate_hold_parameters_roundtrip():
 )
 def test_invalid_hold_parameters(value: dict):
     with pytest.raises(ValueError, match="validation error"):
-        Action("AIR0", "hold_at_location", value)
+        Action("AIR0", "route_direct_to,hold_at_location", value)
 
 
 @pytest.mark.parametrize(

--- a/bluebird-dt/tests/unit/core/test_action.py
+++ b/bluebird-dt/tests/unit/core/test_action.py
@@ -1,7 +1,13 @@
 import pytest
 
-from bluebird_dt.core import Action, HoldAtFixParameters
+from bluebird_dt.core import (
+    Action,
+    HoldAtFixParameters,
+    HoldAtLocationParameters,
+    parse_hold_parameters,
+)
 from bluebird_dt.scenario_manager import TwoAircraft
+
 
 def test_init_exceptions():
     """
@@ -91,7 +97,7 @@ def test_hold_parameters_roundtrip():
     action = Action(
         callsign="AIR0",
         kind="route_direct_to,hold_at_location",
-        value={"fix": "FIX", "outbound_time_s": 60, "turn_direction": "left"},
+        value=HoldAtFixParameters(fix="FIX", outbound_time_s=60, turn_direction="left"),
     )
 
     assert action == Action.from_json(action.to_json())
@@ -99,10 +105,8 @@ def test_hold_parameters_roundtrip():
 
 
 def test_hold_parameters_from_json_string():
-    action = Action(
-        callsign="AIR0",
-        kind="route_direct_to,hold_at_location",
-        value='{"fix":"FIX","outbound_time_s":60,"turn_direction":"left"}',
+    action = Action.from_str(
+        'AIR0 route_direct_to,hold_at_location {"fix":"FIX","outbound_time_s":60,"turn_direction":"left"}'
     )
 
     assert action.value == HoldAtFixParameters(fix="FIX", outbound_time_s=60, turn_direction="left")
@@ -112,7 +116,7 @@ def test_coordinate_hold_parameters_roundtrip():
     action = Action(
         callsign="AIR0",
         kind="route_direct_to,hold_at_location",
-        value={"location": (50.716667, -3.533333), "outbound_time_s": 60},
+        value=HoldAtLocationParameters(location=(50.716667, -3.533333), outbound_time_s=60),
     )
 
     assert action.value.location == (50.716667, -3.533333)
@@ -135,7 +139,12 @@ def test_coordinate_hold_parameters_roundtrip():
 )
 def test_invalid_hold_parameters(value: dict):
     with pytest.raises(ValueError, match="validation error"):
-        Action("AIR0", "route_direct_to,hold_at_location", value)
+        parse_hold_parameters(value)
+
+
+def test_hold_action_rejects_unparsed_mapping():
+    with pytest.raises(TypeError, match="HoldAtFixParameters or HoldAtLocationParameters"):
+        Action("AIR0", "route_direct_to,hold_at_location", {"fix": "FIX"})
 
 
 @pytest.mark.parametrize(

--- a/bluebird-dt/tests/unit/core/test_action.py
+++ b/bluebird-dt/tests/unit/core/test_action.py
@@ -98,6 +98,16 @@ def test_hold_parameters_roundtrip():
     assert action == Action.from_str(str(action))
 
 
+def test_hold_parameters_from_json_string():
+    action = Action(
+        callsign="AIR0",
+        kind="hold_at_location",
+        value='{"fix":"FIX","outbound_time":60,"turn_direction":"left"}',
+    )
+
+    assert action.value == HoldParameters(fix="FIX", outbound_time=60, turn_direction="left")
+
+
 def test_coordinate_hold_parameters_roundtrip():
     action = Action(
         callsign="AIR0",

--- a/bluebird-dt/tests/unit/core/test_action.py
+++ b/bluebird-dt/tests/unit/core/test_action.py
@@ -1,6 +1,6 @@
 import pytest
 
-from bluebird_dt.core import Action, HoldParameters
+from bluebird_dt.core import Action, HoldAtFixParameters
 from bluebird_dt.scenario_manager import TwoAircraft
 
 def test_init_exceptions():
@@ -30,7 +30,7 @@ def test_init_exceptions_from_str():
     "kind, value",
     [
         ("route_direct_to", "FIX"),
-        ("route_direct_to,hold_at_location", HoldParameters(fix="FIX")),
+        ("route_direct_to,hold_at_location", HoldAtFixParameters(fix="FIX")),
         ("change_heading_to", 120),
         ("change_heading_by", -10),
         ("change_flight_level_to", 250),
@@ -105,7 +105,7 @@ def test_hold_parameters_from_json_string():
         value='{"fix":"FIX","outbound_time":60,"turn_direction":"left"}',
     )
 
-    assert action.value == HoldParameters(fix="FIX", outbound_time=60, turn_direction="left")
+    assert action.value == HoldAtFixParameters(fix="FIX", outbound_time=60, turn_direction="left")
 
 
 def test_coordinate_hold_parameters_roundtrip():

--- a/bluebird-dt/tests/unit/core/test_action.py
+++ b/bluebird-dt/tests/unit/core/test_action.py
@@ -98,10 +98,27 @@ def test_hold_parameters_roundtrip():
     assert action == Action.from_str(str(action))
 
 
+def test_coordinate_hold_parameters_roundtrip():
+    action = Action(
+        callsign="AIR0",
+        kind="hold_at_location",
+        value={"location": (50.716667, -3.533333), "outbound_time": 60},
+    )
+
+    assert action.value.location == (50.716667, -3.533333)
+    assert action.value.location_label == "50.7167, -3.53333"
+    assert action == Action.from_json(action.to_json())
+    assert action == Action.from_str(str(action))
+
+
 @pytest.mark.parametrize(
     "value",
     [
+        {},
         {"fix": ""},
+        {"fix": "FIX", "location": (50.0, -3.0)},
+        {"location": (91.0, -3.0)},
+        {"location": (50.0, -181.0)},
         {"fix": "FIX", "outbound_time": 0},
         {"fix": "FIX", "turn_direction": "straight"},
     ],

--- a/bluebird-dt/tests/unit/core/test_action.py
+++ b/bluebird-dt/tests/unit/core/test_action.py
@@ -1,6 +1,6 @@
 import pytest
 
-from bluebird_dt.core import Action
+from bluebird_dt.core import Action, HoldParameters
 from bluebird_dt.scenario_manager import TwoAircraft
 
 def test_init_exceptions():
@@ -30,6 +30,7 @@ def test_init_exceptions_from_str():
     "kind, value",
     [
         ("route_direct_to", "FIX"),
+        ("hold_at_location", HoldParameters(fix="FIX")),
         ("change_heading_to", 120),
         ("change_heading_by", -10),
         ("change_flight_level_to", 250),
@@ -84,6 +85,30 @@ def test_from_str_with_sector():
     action = Action.from_str(action_str)
 
     assert action == expected_action
+
+
+def test_hold_parameters_roundtrip():
+    action = Action(
+        callsign="AIR0",
+        kind="hold_at_location",
+        value={"fix": "FIX", "outbound_time": 60, "turn_direction": "left"},
+    )
+
+    assert action == Action.from_json(action.to_json())
+    assert action == Action.from_str(str(action))
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"fix": ""},
+        {"fix": "FIX", "outbound_time": 0},
+        {"fix": "FIX", "turn_direction": "straight"},
+    ],
+)
+def test_invalid_hold_parameters(value: dict):
+    with pytest.raises(ValueError, match="validation error"):
+        Action("AIR0", "hold_at_location", value)
 
 
 @pytest.mark.parametrize(

--- a/bluebird-dt/tests/unit/core/test_pilot.py
+++ b/bluebird-dt/tests/unit/core/test_pilot.py
@@ -255,6 +255,45 @@ def test_receive_check_process_single_action(generate_simple_environment):
     assert aircraft.current_sector == "background"
 
 
+def test_hold_action_and_lateral_cancellation(generate_simple_environment):
+    environment = generate_simple_environment
+    aircraft = environment.aircraft["AIR0"]
+    hold_fix = next(iter(environment.airspace.fixes.places))
+    hold_action = Action(
+        aircraft.callsign,
+        "hold_at_location",
+        {"fix": hold_fix, "outbound_time": 45, "turn_direction": "left"},
+    )
+
+    aircraft.pilot.receive_actions([hold_action], environment)
+    aircraft.pilot.process_actions(environment)
+
+    assert aircraft.predictor_params["hold"] == {
+        "fix": hold_fix,
+        "outbound_time": 45.0,
+        "turn_direction": "left",
+        "phase": "direct_to_fix",
+        "phase_elapsed": 0.0,
+        "inbound_track": None,
+    }
+    assert aircraft.on_route is False
+
+    aircraft.pilot.receive_actions([Action(aircraft.callsign, "maintain_current_heading", 0)], environment)
+    aircraft.pilot.process_actions(environment)
+
+    assert "hold" not in aircraft.predictor_params
+
+
+def test_hold_rejects_unknown_fix(generate_simple_environment):
+    environment = generate_simple_environment
+    aircraft = environment.aircraft["AIR0"]
+    action = Action(aircraft.callsign, "hold_at_location", {"fix": "NOT_A_FIX"})
+
+    aircraft.pilot.receive_actions([action], environment)
+    with pytest.raises(ValueError, match="Unknown holding fix"):
+        aircraft.pilot.process_actions(environment)
+
+
 def test_pilot_from_complete_json():
     """
     Test the Pilot from_json method on a complete Aircraft json string.

--- a/bluebird-dt/tests/unit/core/test_pilot.py
+++ b/bluebird-dt/tests/unit/core/test_pilot.py
@@ -1,7 +1,16 @@
 import logging
+
 import pytest
 
-from bluebird_dt.core import Action, Aircraft, Pilot, Pos2D, QueueItem
+from bluebird_dt.core import (
+    Action,
+    Aircraft,
+    HoldAtFixParameters,
+    HoldAtLocationParameters,
+    Pilot,
+    Pos2D,
+    QueueItem,
+)
 
 
 def test_init():
@@ -262,7 +271,7 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
     hold_action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"fix": hold_fix, "outbound_time_s": 45, "turn_direction": "left"},
+        HoldAtFixParameters(fix=hold_fix, outbound_time_s=45, turn_direction="left"),
     )
 
     aircraft.pilot.receive_actions([hold_action], environment)
@@ -291,7 +300,11 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
 def test_hold_rejects_unknown_fix(generate_simple_environment):
     environment = generate_simple_environment
     aircraft = environment.aircraft["AIR0"]
-    action = Action(aircraft.callsign, "route_direct_to,hold_at_location", {"fix": "NOT_A_FIX"})
+    action = Action(
+        aircraft.callsign,
+        "route_direct_to,hold_at_location",
+        HoldAtFixParameters(fix="NOT_A_FIX"),
+    )
 
     aircraft.pilot.receive_actions([action], environment)
     with pytest.raises(ValueError, match="Unknown holding fix"):
@@ -302,7 +315,11 @@ def test_hold_at_coordinate(generate_simple_environment):
     environment = generate_simple_environment
     aircraft = environment.aircraft["AIR0"]
     location = (51.25, -1.75)
-    action = Action(aircraft.callsign, "route_direct_to,hold_at_location", {"location": location})
+    action = Action(
+        aircraft.callsign,
+        "route_direct_to,hold_at_location",
+        HoldAtLocationParameters(location=location),
+    )
 
     aircraft.pilot.process_lateral_actions(action, environment)
 

--- a/bluebird-dt/tests/unit/core/test_pilot.py
+++ b/bluebird-dt/tests/unit/core/test_pilot.py
@@ -261,7 +261,7 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
     hold_fix = next(iter(environment.airspace.fixes.places))
     hold_action = Action(
         aircraft.callsign,
-        "hold_at_location",
+        "route_direct_to,hold_at_location",
         {"fix": hold_fix, "outbound_time": 45, "turn_direction": "left"},
     )
 
@@ -276,7 +276,7 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
         ],
         "outbound_time": 45.0,
         "turn_direction": "left",
-        "phase": "direct_to_fix",
+        "phase": "direct_to_location",
         "phase_elapsed": 0.0,
         "inbound_track": None,
     }
@@ -291,7 +291,7 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
 def test_hold_rejects_unknown_fix(generate_simple_environment):
     environment = generate_simple_environment
     aircraft = environment.aircraft["AIR0"]
-    action = Action(aircraft.callsign, "hold_at_location", {"fix": "NOT_A_FIX"})
+    action = Action(aircraft.callsign, "route_direct_to,hold_at_location", {"fix": "NOT_A_FIX"})
 
     aircraft.pilot.receive_actions([action], environment)
     with pytest.raises(ValueError, match="Unknown holding fix"):
@@ -302,7 +302,7 @@ def test_hold_at_coordinate(generate_simple_environment):
     environment = generate_simple_environment
     aircraft = environment.aircraft["AIR0"]
     location = (51.25, -1.75)
-    action = Action(aircraft.callsign, "hold_at_location", {"location": location})
+    action = Action(aircraft.callsign, "route_direct_to,hold_at_location", {"location": location})
 
     aircraft.pilot.process_lateral_actions(action, environment)
 

--- a/bluebird-dt/tests/unit/core/test_pilot.py
+++ b/bluebird-dt/tests/unit/core/test_pilot.py
@@ -262,7 +262,7 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
     hold_action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"fix": hold_fix, "outbound_time": 45, "turn_direction": "left"},
+        {"fix": hold_fix, "outbound_time_s": 45, "turn_direction": "left"},
     )
 
     aircraft.pilot.receive_actions([hold_action], environment)
@@ -274,7 +274,7 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
             environment.airspace.fixes.places[hold_fix].lat,
             environment.airspace.fixes.places[hold_fix].lon,
         ],
-        "outbound_time": 45.0,
+        "outbound_time_s": 45.0,
         "turn_direction": "left",
         "phase": "direct_to_location",
         "phase_elapsed": 0.0,

--- a/bluebird-dt/tests/unit/core/test_pilot.py
+++ b/bluebird-dt/tests/unit/core/test_pilot.py
@@ -1,7 +1,7 @@
 import logging
 import pytest
 
-from bluebird_dt.core import Action, Aircraft, Pilot, QueueItem
+from bluebird_dt.core import Action, Aircraft, Pilot, Pos2D, QueueItem
 
 
 def test_init():
@@ -270,6 +270,10 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
 
     assert aircraft.predictor_params["hold"] == {
         "fix": hold_fix,
+        "location": [
+            environment.airspace.fixes.places[hold_fix].lat,
+            environment.airspace.fixes.places[hold_fix].lon,
+        ],
         "outbound_time": 45.0,
         "turn_direction": "left",
         "phase": "direct_to_fix",
@@ -292,6 +296,19 @@ def test_hold_rejects_unknown_fix(generate_simple_environment):
     aircraft.pilot.receive_actions([action], environment)
     with pytest.raises(ValueError, match="Unknown holding fix"):
         aircraft.pilot.process_actions(environment)
+
+
+def test_hold_at_coordinate(generate_simple_environment):
+    environment = generate_simple_environment
+    aircraft = environment.aircraft["AIR0"]
+    location = (51.25, -1.75)
+    action = Action(aircraft.callsign, "hold_at_location", {"location": location})
+
+    aircraft.pilot.process_lateral_actions(action, environment)
+
+    assert aircraft.predictor_params["hold"]["fix"] is None
+    assert aircraft.predictor_params["hold"]["location"] == list(location)
+    assert aircraft.heading_changing_to == pytest.approx(aircraft.pos2d().bearing_to(Pos2D(*location)))
 
 
 def test_pilot_from_complete_json():

--- a/bluebird-dt/tests/unit/events/test_event_handler.py
+++ b/bluebird-dt/tests/unit/events/test_event_handler.py
@@ -11,7 +11,13 @@ from bluebird_dt.events.event_handler import (
 )
 from bluebird_dt.events.event_logger import EventLogger
 from bluebird_dt.events.event_dtypes import EventDtypes
-from bluebird_dt.core import Aircraft, Coordination, Environment, WindField
+from bluebird_dt.core import (
+    Aircraft,
+    Coordination,
+    Environment,
+    HoldAtLocationParameters,
+    WindField,
+)
 from conftest import (
     pick_random_next_sector, build_default_test_df, is_deeply_equal, setup_test_sim, get_to_and_from_sectors, 
     build_test_df_for_multiple_ac, build_coordination_test_df
@@ -1132,6 +1138,19 @@ class TestUpdateFromClearances():
         update_from_clearances(env, manager, df, episode_start, episode_end, ignore_simmed=True)
         manager.process_actions()
         assert all(ac.cleared_instructions.fl != self.mock_fl for ac in env.aircraft.values())
+
+    def test_parses_hold_parameters(self):
+        env, manager, _, _, episode_start, episode_end = setup_test_sim()
+        props_to_set = [
+            ("kind", "route_direct_to,hold_at_location"),
+            ("value", '{"location":[51.0,-1.0],"outbound_time_s":60.0,"turn_direction":"left"}'),
+        ]
+        df = build_test_df_for_multiple_ac(EventDtypes.clearance_dtypes, env, props_to_set)
+
+        update_from_clearances(env, manager, df, episode_start, episode_end, ignore_simmed=False)
+
+        assert manager._actions_to_issue
+        assert all(isinstance(action.value, HoldAtLocationParameters) for action in manager._actions_to_issue)
 
 
 class TestUpdateAirspaceConfiguration:

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -2,7 +2,7 @@ from itertools import pairwise
 
 import pytest
 
-from bluebird_dt.core import Action, Environment
+from bluebird_dt.core import Action, Environment, HoldAtFixParameters, HoldAtLocationParameters
 from bluebird_dt.predictor import SimplePredictor
 
 
@@ -15,7 +15,7 @@ def test_repeating_standard_rate_hold(generate_simple_environment: Environment):
     action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"fix": "EARTH", "outbound_time_s": 30, "turn_direction": "right"},
+        HoldAtFixParameters(fix="EARTH", outbound_time_s=30, turn_direction="right"),
     )
     aircraft.pilot.process_lateral_actions(action, environment)
 
@@ -84,7 +84,7 @@ def test_coordinate_hold_does_not_require_predictor_fixes(generate_simple_enviro
     action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"location": (hold_position.lat, hold_position.lon), "outbound_time_s": 30},
+        HoldAtLocationParameters(location=(hold_position.lat, hold_position.lon), outbound_time_s=30),
     )
     aircraft.pilot.process_lateral_actions(action, environment)
 

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -15,7 +15,7 @@ def test_repeating_standard_rate_hold(generate_simple_environment: Environment):
     action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"fix": "EARTH", "outbound_time": 30, "turn_direction": "right"},
+        {"fix": "EARTH", "outbound_time_s": 30, "turn_direction": "right"},
     )
     aircraft.pilot.process_lateral_actions(action, environment)
 
@@ -62,7 +62,7 @@ def test_hold_state_survives_aircraft_json_roundtrip(generate_simple_environment
     aircraft = generate_simple_environment.aircraft["AIR0"]
     aircraft.predictor_params["hold"] = {
         "fix": "EARTH",
-        "outbound_time": 90.0,
+        "outbound_time_s": 90.0,
         "turn_direction": "left",
         "phase": "outbound",
         "phase_elapsed": 12.0,
@@ -84,7 +84,7 @@ def test_coordinate_hold_does_not_require_predictor_fixes(generate_simple_enviro
     action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"location": (hold_position.lat, hold_position.lon), "outbound_time": 30},
+        {"location": (hold_position.lat, hold_position.lon), "outbound_time_s": 30},
     )
     aircraft.pilot.process_lateral_actions(action, environment)
 

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -14,7 +14,7 @@ def test_repeating_standard_rate_hold(generate_simple_environment: Environment):
     predictor = SimplePredictor(1.0, 2.0, fixes=environment.airspace.fixes)
     action = Action(
         aircraft.callsign,
-        "hold_at_location",
+        "route_direct_to,hold_at_location",
         {"fix": "EARTH", "outbound_time": 30, "turn_direction": "right"},
     )
     aircraft.pilot.process_lateral_actions(action, environment)
@@ -83,7 +83,7 @@ def test_coordinate_hold_does_not_require_predictor_fixes(generate_simple_enviro
     predictor = SimplePredictor(1.0, 2.0, fixes=None)
     action = Action(
         aircraft.callsign,
-        "hold_at_location",
+        "route_direct_to,hold_at_location",
         {"location": (hold_position.lat, hold_position.lon), "outbound_time": 30},
     )
     aircraft.pilot.process_lateral_actions(action, environment)
@@ -91,4 +91,4 @@ def test_coordinate_hold_does_not_require_predictor_fixes(generate_simple_enviro
     for _ in range(300):
         predictor.predict_aircraft(aircraft, 1.0, deepcopy_aircraft=False)
 
-    assert aircraft.predictor_params["hold"]["phase"] != "direct_to_fix"
+    assert aircraft.predictor_params["hold"]["phase"] != "direct_to_location"

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -1,0 +1,74 @@
+from itertools import pairwise
+
+import pytest
+
+from bluebird_dt.core import Action, Environment
+from bluebird_dt.predictor import SimplePredictor
+
+
+def test_repeating_standard_rate_hold(generate_simple_environment: Environment):
+    environment = generate_simple_environment
+    aircraft = environment.aircraft["AIR0"]
+    aircraft.selected_instructions.cas = 360
+    aircraft.cleared_instructions.cas = 360
+    predictor = SimplePredictor(1.0, 2.0, fixes=environment.airspace.fixes)
+    action = Action(
+        aircraft.callsign,
+        "hold_at_location",
+        {"fix": "EARTH", "outbound_time": 30, "turn_direction": "right"},
+    )
+    aircraft.pilot.process_lateral_actions(action, environment)
+
+    transitions = []
+    turn_headings = []
+    previous_phase = aircraft.predictor_params["hold"]["phase"]
+
+    for elapsed in range(1, 501):
+        predictor.predict_aircraft(aircraft, 1.0, deepcopy_aircraft=False)
+        phase = aircraft.predictor_params["hold"]["phase"]
+        if phase != previous_phase:
+            transitions.append((phase, elapsed, aircraft.pos2d()))
+            previous_phase = phase
+        if phase in ["turn_outbound", "turn_inbound"]:
+            turn_headings.append(aircraft.heading)
+
+    phases = [transition[0] for transition in transitions]
+    assert phases[:6] == [
+        "turn_outbound",
+        "outbound",
+        "turn_inbound",
+        "inbound",
+        "turn_outbound",
+        "outbound",
+    ]
+
+    transition_times = [transition[1] for transition in transitions]
+    assert transition_times[1] - transition_times[0] == 60
+    assert transition_times[2] - transition_times[1] == 30
+    assert transition_times[3] - transition_times[2] == 60
+    assert transition_times[5] - transition_times[4] == 60
+
+    hold_fix = environment.airspace.fixes.places["EARTH"]
+    first_turn_position = transitions[0][2]
+    second_turn_position = transitions[4][2]
+    assert first_turn_position.distance(hold_fix) <= 2.2
+    assert second_turn_position.distance(hold_fix) <= 2.2
+
+    turn_deltas = [(second - first) % 360 for first, second in pairwise(turn_headings)]
+    assert max(delta for delta in turn_deltas if delta < 10.0) == pytest.approx(3.0, abs=0.01)
+
+
+def test_hold_state_survives_aircraft_json_roundtrip(generate_simple_environment: Environment):
+    aircraft = generate_simple_environment.aircraft["AIR0"]
+    aircraft.predictor_params["hold"] = {
+        "fix": "EARTH",
+        "outbound_time": 90.0,
+        "turn_direction": "left",
+        "phase": "outbound",
+        "phase_elapsed": 12.0,
+        "inbound_track": 0.0,
+    }
+
+    restored = aircraft.from_json(aircraft.to_json())
+
+    assert restored.predictor_params["hold"] == aircraft.predictor_params["hold"]

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -72,3 +72,23 @@ def test_hold_state_survives_aircraft_json_roundtrip(generate_simple_environment
     restored = aircraft.from_json(aircraft.to_json())
 
     assert restored.predictor_params["hold"] == aircraft.predictor_params["hold"]
+
+
+def test_coordinate_hold_does_not_require_predictor_fixes(generate_simple_environment: Environment):
+    environment = generate_simple_environment
+    aircraft = environment.aircraft["AIR0"]
+    aircraft.selected_instructions.cas = 360
+    aircraft.cleared_instructions.cas = 360
+    hold_position = environment.airspace.fixes.places["EARTH"]
+    predictor = SimplePredictor(1.0, 2.0, fixes=None)
+    action = Action(
+        aircraft.callsign,
+        "hold_at_location",
+        {"location": (hold_position.lat, hold_position.lon), "outbound_time": 30},
+    )
+    aircraft.pilot.process_lateral_actions(action, environment)
+
+    for _ in range(300):
+        predictor.predict_aircraft(aircraft, 1.0, deepcopy_aircraft=False)
+
+    assert aircraft.predictor_params["hold"]["phase"] != "direct_to_fix"

--- a/bluebird-dt/tests/unit/utility/test_clearance.py
+++ b/bluebird-dt/tests/unit/utility/test_clearance.py
@@ -1,7 +1,8 @@
 import logging
+
 import pytest
 
-from bluebird_dt.core import Action, Environment
+from bluebird_dt.core import Action, Environment, HoldAtFixParameters, HoldAtLocationParameters
 from bluebird_dt.utility.clearance import (
     add_phraseology,
     beautify_callsign,
@@ -317,7 +318,7 @@ def test_hold_clearance(env: Environment):
     action = Action(
         "AIR0",
         "route_direct_to,hold_at_location",
-        {"fix": "ALPHA", "outbound_time_s": 90.0, "turn_direction": "right"},
+        HoldAtFixParameters(fix="ALPHA", outbound_time_s=90.0, turn_direction="right"),
     )
 
     assert_action_voice_and_text(
@@ -334,7 +335,7 @@ def test_coordinate_hold_clearance(env: Environment):
     action = Action(
         "AIR0",
         "route_direct_to,hold_at_location",
-        {"location": (50.716667, -3.533333), "outbound_time_s": 90.0},
+        HoldAtLocationParameters(location=(50.716667, -3.533333), outbound_time_s=90.0),
     )
 
     assert_action_voice_and_text(

--- a/bluebird-dt/tests/unit/utility/test_clearance.py
+++ b/bluebird-dt/tests/unit/utility/test_clearance.py
@@ -316,7 +316,7 @@ def test_change_mach_clearance(env: Environment):
 def test_hold_clearance(env: Environment):
     action = Action(
         "AIR0",
-        "hold_at_location",
+        "route_direct_to,hold_at_location",
         {"fix": "ALPHA", "outbound_time": 90.0, "turn_direction": "right"},
     )
 
@@ -333,7 +333,7 @@ def test_hold_clearance(env: Environment):
 def test_coordinate_hold_clearance(env: Environment):
     action = Action(
         "AIR0",
-        "hold_at_location",
+        "route_direct_to,hold_at_location",
         {"location": (50.716667, -3.533333), "outbound_time": 90.0},
     )
 

--- a/bluebird-dt/tests/unit/utility/test_clearance.py
+++ b/bluebird-dt/tests/unit/utility/test_clearance.py
@@ -312,6 +312,23 @@ def test_change_mach_clearance(env: Environment):
             env,
             )
 
+
+def test_hold_clearance(env: Environment):
+    action = Action(
+        "AIR0",
+        "hold_at_location",
+        {"fix": "ALPHA", "outbound_time": 90.0, "turn_direction": "right"},
+    )
+
+    assert_action_voice_and_text(
+        action,
+        "AIR0 hold at ALPHA right hand outbound time 1.5 minutes",
+        "hold at ALPHA right hand outbound time 1.5 minutes AIR0",
+        "alpha india romeo zero hold at ALPHA right hand outbound time 1.5 minutes",
+        "hold at ALPHA right hand outbound time 1.5 minutes alpha india romeo zero",
+        env,
+    )
+
 def test_outcomm_clearance(env: Environment):
     action = Action("AIR0", "outcomm", None)
 

--- a/bluebird-dt/tests/unit/utility/test_clearance.py
+++ b/bluebird-dt/tests/unit/utility/test_clearance.py
@@ -329,6 +329,23 @@ def test_hold_clearance(env: Environment):
         env,
     )
 
+
+def test_coordinate_hold_clearance(env: Environment):
+    action = Action(
+        "AIR0",
+        "hold_at_location",
+        {"location": (50.716667, -3.533333), "outbound_time": 90.0},
+    )
+
+    assert_action_voice_and_text(
+        action,
+        "AIR0 hold at latitude 50.7167 longitude -3.53333 right hand outbound time 1.5 minutes",
+        "hold at latitude 50.7167 longitude -3.53333 right hand outbound time 1.5 minutes AIR0",
+        "alpha india romeo zero hold at latitude 50.7167 longitude -3.53333 right hand outbound time 1.5 minutes",
+        "hold at latitude 50.7167 longitude -3.53333 right hand outbound time 1.5 minutes alpha india romeo zero",
+        env,
+    )
+
 def test_outcomm_clearance(env: Environment):
     action = Action("AIR0", "outcomm", None)
 

--- a/bluebird-dt/tests/unit/utility/test_clearance.py
+++ b/bluebird-dt/tests/unit/utility/test_clearance.py
@@ -317,7 +317,7 @@ def test_hold_clearance(env: Environment):
     action = Action(
         "AIR0",
         "route_direct_to,hold_at_location",
-        {"fix": "ALPHA", "outbound_time": 90.0, "turn_direction": "right"},
+        {"fix": "ALPHA", "outbound_time_s": 90.0, "turn_direction": "right"},
     )
 
     assert_action_voice_and_text(
@@ -334,7 +334,7 @@ def test_coordinate_hold_clearance(env: Environment):
     action = Action(
         "AIR0",
         "route_direct_to,hold_at_location",
-        {"location": (50.716667, -3.533333), "outbound_time": 90.0},
+        {"location": (50.716667, -3.533333), "outbound_time_s": 90.0},
     )
 
     assert_action_voice_and_text(


### PR DESCRIPTION
## Summary

- add a structured `hold_at_location` action with fix, outbound-time, and turn-direction parameters
- implement a repeating racetrack hold using fixed 3 degree-per-second turns, wind-corrected tracks, and serializable predictor state
- cancel the hold on a subsequent lateral clearance and support simultaneous level and speed clearances
- add text/voice phraseology and unit coverage for parsing, pilot handling, geometry, timing, and persistence

## Testing

- `824 passed` in the BluebirdDT unit suite
- Ruff checks passed for the changed Python sources
