### PR TITLE
Implement standard hold entries

### DIFF
--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -21,12 +21,12 @@ class ClearanceAndResponse(BaseModel):
 class HoldParametersBase(BaseModel):
     """Parameters common to all racetrack hold targets."""
 
-    inbound_course_deg: typing.Annotated[
+    hold_orientation_deg: typing.Annotated[
         float,
         Field(
             ge=0.0,
             lt=360.0,
-            description="Course in degrees flown inbound towards the holding fix",
+            description="Bearing in degrees from the fix towards the outbound end of the hold",
         ),
     ]
     outbound_time_s: float = Field(default=90.0, gt=0.0, description="Outbound leg duration in seconds")
@@ -125,8 +125,8 @@ class Action(Comparison):
             Allowed values for each Action kind differs:
 
             - `route_direct_to`: str or list[str]
-            - `route_direct_to,hold_at_location`: HoldParameters or an equivalent dict; `inbound_course_deg`
-                defines the hold axis and enables automatic direct, parallel, or teardrop entry selection
+            - `route_direct_to,hold_at_location`: HoldParameters or an equivalent dict; `hold_orientation_deg`
+                specifies the bearing from the fix towards the outbound end, from which the inbound course is calculated
             - `change_heading_to`: int
             - `change_heading_to_by_direction`: tuple[int, Literal['left', 'right', 'shortest']]
             - `change_heading_by`: int

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -19,9 +19,22 @@ class ClearanceAndResponse(BaseModel):
 
 
 class HoldParametersBase(BaseModel):
-    """Parameters common to all racetrack hold targets."""
+    """Parameters common to all racetrack hold targets.
 
-    outbound_time_s: float = Field(default=90.0, gt=0.0)
+    If no inbound course is supplied, the hold is aligned with the arrival
+    track and therefore uses a direct entry, preserving the simple-hold
+    behaviour.
+    """
+
+    inbound_course_deg: typing.Annotated[
+        float,
+        Field(
+            ge=0.0,
+            lt=360.0,
+            description="Course in degrees flown inbound towards the holding fix",
+        ),
+    ] | None = None
+    outbound_time_s: float = Field(default=90.0, gt=0.0, description="Outbound leg duration in seconds")
     turn_direction: typing.Literal["left", "right"] = "right"
 
     def __str__(self) -> str:
@@ -117,7 +130,8 @@ class Action(Comparison):
             Allowed values for each Action kind differs:
 
             - `route_direct_to`: str or list[str]
-            - `route_direct_to,hold_at_location`: HoldParameters or an equivalent dict
+            - `route_direct_to,hold_at_location`: HoldParameters or an equivalent dict; `inbound_course_deg`
+                defines the hold axis and enables automatic direct, parallel, or teardrop entry selection
             - `change_heading_to`: int
             - `change_heading_to_by_direction`: tuple[int, Literal['left', 'right', 'shortest']]
             - `change_heading_by`: int

--- a/bluebird-dt/bluebird_dt/core/action.py
+++ b/bluebird-dt/bluebird_dt/core/action.py
@@ -19,12 +19,7 @@ class ClearanceAndResponse(BaseModel):
 
 
 class HoldParametersBase(BaseModel):
-    """Parameters common to all racetrack hold targets.
-
-    If no inbound course is supplied, the hold is aligned with the arrival
-    track and therefore uses a direct entry, preserving the simple-hold
-    behaviour.
-    """
+    """Parameters common to all racetrack hold targets."""
 
     inbound_course_deg: typing.Annotated[
         float,
@@ -33,7 +28,7 @@ class HoldParametersBase(BaseModel):
             lt=360.0,
             description="Course in degrees flown inbound towards the holding fix",
         ),
-    ] | None = None
+    ]
     outbound_time_s: float = Field(default=90.0, gt=0.0, description="Outbound leg duration in seconds")
     turn_direction: typing.Literal["left", "right"] = "right"
 

--- a/bluebird-dt/bluebird_dt/core/pilot.py
+++ b/bluebird-dt/bluebird_dt/core/pilot.py
@@ -269,11 +269,12 @@ class Pilot:
             aircraft.predictor_params["hold"] = {
                 "fix": hold.fix,
                 "location": [target_pos.lat, target_pos.lon],
+                "inbound_course_deg": hold.inbound_course_deg,
                 "outbound_time_s": hold.outbound_time_s,
                 "turn_direction": hold.turn_direction,
                 "phase": "direct_to_location",
                 "phase_elapsed": 0.0,
-                "inbound_track": None,
+                "entry_type": None,
             }
 
         elif action.kind == "route_direct_to":

--- a/bluebird-dt/bluebird_dt/core/pilot.py
+++ b/bluebird-dt/bluebird_dt/core/pilot.py
@@ -269,7 +269,7 @@ class Pilot:
             aircraft.predictor_params["hold"] = {
                 "fix": hold.fix,
                 "location": [target_pos.lat, target_pos.lon],
-                "inbound_course_deg": hold.inbound_course_deg,
+                "inbound_course_deg": (hold.hold_orientation_deg + 180.0) % 360.0,
                 "outbound_time_s": hold.outbound_time_s,
                 "turn_direction": hold.turn_direction,
                 "phase": "direct_to_location",

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -530,15 +530,11 @@ class Predictor(ABC):
             distance_to_location = aircraft.pos2d().distance(target_pos)
             if distance_to_location <= self.fix_proximity_threshold:
                 if phase == "direct_to_location":
-                    if hold["inbound_course_deg"] is None:
-                        hold["inbound_course_deg"] = ground_track_angle
-                        entry_type = "direct"
-                    else:
-                        entry_type = self.select_hold_entry(
-                            ground_track_angle,
-                            hold["inbound_course_deg"],
-                            hold["turn_direction"],
-                        )
+                    entry_type = self.select_hold_entry(
+                        ground_track_angle,
+                        hold["inbound_course_deg"],
+                        hold["turn_direction"],
+                    )
                     hold["entry_type"] = entry_type
                     hold["phase"] = {
                         "direct": "turn_outbound",
@@ -558,8 +554,6 @@ class Predictor(ABC):
                 return
 
         inbound_course_deg = hold["inbound_course_deg"]
-        if inbound_course_deg is None:
-            raise ValueError("Hold state has no inbound course")
         outbound_track = (inbound_course_deg + 180.0) % 360.0
 
         outbound_turn_phases = {

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -25,8 +25,9 @@ DEFAULT_RATE_OF_TURN = 1.5
 # configured rate for ordinary heading changes.  According to ICAO 8168 section 2.1.2, all turns
 # shall be made at a bank angle of 25° or at a rate of 3° per second, whichever requires the lesser bank.
 HOLD_RATE_OF_TURN_s = 3.0
-# Parallel and teardrop entry timing starts when the holding fix is crossed,
-# including the initial turn onto the entry's outbound track.
+# Parallel entry timing starts when the holding fix is crossed. Teardrop entry
+# timing starts after the initial turn so that its outbound track is flown
+# straight for the full entry time.
 HOLD_ENTRY_TIME_s = 60.0
 HOLD_TEARDROP_ANGLE_deg = 30.0
 # Hold guidance can change phase at the fix, at the end of a turn, or at the
@@ -597,7 +598,7 @@ class Predictor(ABC):
             target_track, next_phase = outbound_turn_phases[phase]
             if aircraft.heading_changing_to is None and not entered_turn:
                 hold["phase"] = next_phase
-                if phase == "turn_outbound":
+                if phase in {"turn_outbound", "teardrop_turn_outbound"}:
                     hold["phase_elapsed"] = 0.0
                 aircraft.heading = heading_from_ground_track(target_track, horizontal_speed_kts, wind_vector)
             else:

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -25,6 +25,23 @@ DEFAULT_RATE_OF_TURN = 1.5
 # configured rate for ordinary heading changes.  According to ICAO 8168 section 2.1.2, all turns
 # shall be made at a bank angle of 25° or at a rate of 3° per second, whichever requires the lesser bank.
 HOLD_RATE_OF_TURN_s = 3.0
+HOLD_ENTRY_LEG_TIME_s = 60.0
+HOLD_TEARDROP_ANGLE_deg = 30.0
+
+HOLD_TURN_PHASES = frozenset(
+    {
+        "turn_outbound",
+        "turn_inbound",
+        "parallel_turn_outbound",
+        "parallel_turn_inbound",
+        "teardrop_turn_outbound",
+        "teardrop_turn_inbound",
+    }
+)
+HOLD_DIRECTION_TURN_PHASES = frozenset(
+    {"turn_outbound", "turn_inbound", "parallel_turn_inbound", "teardrop_turn_inbound"}
+)
+HOLD_TIMED_LEG_PHASES = frozenset({"outbound", "parallel_outbound", "teardrop_outbound"})
 
 # Threshold difference (in degrees) between requested heading and actual heading. Below this threshold
 # the heading is automatically updated, without an explicit use of a turn model.
@@ -399,7 +416,7 @@ class Predictor(ABC):
             current_bearing = ground_track_angle
 
             rate_of_turn = aircraft.rate_of_turn if aircraft.rate_of_turn else DEFAULT_RATE_OF_TURN
-            if hold is not None and hold["phase"] in ["turn_outbound", "turn_inbound"]:
+            if hold is not None and hold["phase"] in HOLD_TURN_PHASES:
                 rate_of_turn = HOLD_RATE_OF_TURN_s
             # If have started a route turn, then continue the turn at same radius. So calculate the rate of turn
             # from ground speed and turn radius. This means that speed changes won't affect the turn radius.
@@ -411,7 +428,7 @@ class Predictor(ABC):
             turn_direction: Literal["left", "right"] | None = None
 
             # If aircraft is flying a heading
-            if hold is not None and hold["phase"] in ["turn_outbound", "turn_inbound"]:
+            if hold is not None and hold["phase"] in HOLD_DIRECTION_TURN_PHASES:
                 turn_direction = hold["turn_direction"]
             elif (
                 aircraft.cleared_instructions.lateral_action is not None
@@ -465,8 +482,28 @@ class Predictor(ABC):
         aircraft.lat = new_pos.lat
         aircraft.lon = new_pos.lon
 
-        if hold is not None and hold["phase"] == "outbound":
+        if hold is not None and hold["phase"] in HOLD_TIMED_LEG_PHASES:
             hold["phase_elapsed"] += time_evolve
+
+    @staticmethod
+    def select_hold_entry(
+        arrival_track_deg: float,
+        inbound_course_deg: float,
+        turn_direction: Literal["left", "right"],
+    ) -> Literal["direct", "parallel", "teardrop"]:
+        """Select the standard entry sector for a hold.
+
+        Sector boundaries are mirrored for left-hand holds. An aircraft on an
+        exact 70-degree boundary uses the direct entry; the reciprocal-course
+        boundary uses the parallel entry.
+        """
+        direction_sign = 1.0 if turn_direction == "right" else -1.0
+        relative_track = (direction_sign * (arrival_track_deg - inbound_course_deg)) % 360.0
+        if 110.0 < relative_track < 180.0:
+            return "teardrop"
+        if 180.0 <= relative_track < 290.0:
+            return "parallel"
+        return "direct"
 
     def update_hold_guidance(
         self,
@@ -488,14 +525,30 @@ class Predictor(ABC):
         phase = hold["phase"]
         entered_turn = False
 
-        if phase in ["direct_to_location", "inbound"]:
+        inbound_phases = ["direct_to_location", "inbound", "parallel_inbound", "teardrop_inbound"]
+        if phase in inbound_phases:
             distance_to_location = aircraft.pos2d().distance(target_pos)
             if distance_to_location <= self.fix_proximity_threshold:
-                if hold["inbound_track"] is None:
-                    hold["inbound_track"] = ground_track_angle
-                hold["phase"] = "turn_outbound"
+                if phase == "direct_to_location":
+                    if hold["inbound_course_deg"] is None:
+                        hold["inbound_course_deg"] = ground_track_angle
+                        entry_type = "direct"
+                    else:
+                        entry_type = self.select_hold_entry(
+                            ground_track_angle,
+                            hold["inbound_course_deg"],
+                            hold["turn_direction"],
+                        )
+                    hold["entry_type"] = entry_type
+                    hold["phase"] = {
+                        "direct": "turn_outbound",
+                        "parallel": "parallel_turn_outbound",
+                        "teardrop": "teardrop_turn_outbound",
+                    }[entry_type]
+                else:
+                    hold["phase"] = "turn_outbound"
                 hold["phase_elapsed"] = 0.0
-                phase = "turn_outbound"
+                phase = hold["phase"]
                 entered_turn = True
             else:
                 target_track = aircraft.pos2d().bearing_to(target_pos)
@@ -504,10 +557,27 @@ class Predictor(ABC):
                 )
                 return
 
-        if phase == "turn_outbound":
-            target_track = (hold["inbound_track"] + 180.0) % 360.0
+        inbound_course_deg = hold["inbound_course_deg"]
+        if inbound_course_deg is None:
+            raise ValueError("Hold state has no inbound course")
+        outbound_track = (inbound_course_deg + 180.0) % 360.0
+
+        outbound_turn_phases = {
+            "turn_outbound": (outbound_track, "outbound"),
+            "parallel_turn_outbound": (outbound_track, "parallel_outbound"),
+            "teardrop_turn_outbound": (
+                (
+                    outbound_track
+                    - (HOLD_TEARDROP_ANGLE_deg if hold["turn_direction"] == "right" else -HOLD_TEARDROP_ANGLE_deg)
+                )
+                % 360.0,
+                "teardrop_outbound",
+            ),
+        }
+        if phase in outbound_turn_phases:
+            target_track, next_phase = outbound_turn_phases[phase]
             if aircraft.heading_changing_to is None and not entered_turn:
-                hold["phase"] = "outbound"
+                hold["phase"] = next_phase
                 hold["phase_elapsed"] = 0.0
                 aircraft.heading = heading_from_ground_track(target_track, horizontal_speed_kts, wind_vector)
             else:
@@ -516,12 +586,30 @@ class Predictor(ABC):
                 )
             return
 
-        if phase == "outbound":
-            target_track = (hold["inbound_track"] + 180.0) % 360.0
-            if hold["phase_elapsed"] >= hold["outbound_time_s"]:
-                hold["phase"] = "turn_inbound"
+        timed_leg_phases = {
+            "outbound": (hold["outbound_time_s"], "turn_inbound"),
+            "parallel_outbound": (HOLD_ENTRY_LEG_TIME_s, "parallel_turn_inbound"),
+            "teardrop_outbound": (HOLD_ENTRY_LEG_TIME_s, "teardrop_turn_inbound"),
+        }
+        if phase in timed_leg_phases:
+            leg_time_s, next_phase = timed_leg_phases[phase]
+            target_track = (
+                outbound_track
+                if phase != "teardrop_outbound"
+                else (
+                    outbound_track
+                    - (HOLD_TEARDROP_ANGLE_deg if hold["turn_direction"] == "right" else -HOLD_TEARDROP_ANGLE_deg)
+                )
+                % 360.0
+            )
+            if hold["phase_elapsed"] >= leg_time_s:
+                hold["phase"] = next_phase
                 hold["phase_elapsed"] = 0.0
-                target_track = hold["inbound_track"]
+                target_track = (
+                    inbound_course_deg
+                    if next_phase == "turn_inbound"
+                    else aircraft.pos2d().bearing_to(target_pos)
+                )
                 aircraft.heading_changing_to = heading_from_ground_track(
                     target_track, horizontal_speed_kts, wind_vector
                 )
@@ -530,10 +618,17 @@ class Predictor(ABC):
                 aircraft.heading_changing_to = None
             return
 
-        if phase == "turn_inbound":
-            target_track = hold["inbound_track"]
+        inbound_turn_phases = {
+            "turn_inbound": "inbound",
+            "parallel_turn_inbound": "parallel_inbound",
+            "teardrop_turn_inbound": "teardrop_inbound",
+        }
+        if phase in inbound_turn_phases:
+            target_track = (
+                inbound_course_deg if phase == "turn_inbound" else aircraft.pos2d().bearing_to(target_pos)
+            )
             if aircraft.heading_changing_to is None:
-                hold["phase"] = "inbound"
+                hold["phase"] = inbound_turn_phases[phase]
                 aircraft.heading = heading_from_ground_track(target_track, horizontal_speed_kts, wind_vector)
             else:
                 aircraft.heading_changing_to = heading_from_ground_track(
@@ -541,7 +636,7 @@ class Predictor(ABC):
                 )
             return
 
-        if phase != "inbound":
+        if phase not in inbound_phases:
             raise ValueError(f"Unrecognised hold phase: {phase}")
 
     def update_position_without_turn_model(self, aircraft: Aircraft, time_evolve: float, wind_field: WindField | None):

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -29,6 +29,10 @@ HOLD_RATE_OF_TURN_s = 3.0
 # including the initial turn onto the entry's outbound track.
 HOLD_ENTRY_TIME_s = 60.0
 HOLD_TEARDROP_ANGLE_deg = 30.0
+# Hold guidance can change phase at the fix, at the end of a turn, or at the
+# end of a timed leg. Limit its lateral integration step so a coarse predictor
+# timestep cannot skip those transitions or apply one phase for the full step.
+HOLD_MAX_INTEGRATION_STEP_s = 1.0
 
 HOLD_TURN_PHASES = frozenset(
     {
@@ -324,8 +328,17 @@ class Predictor(ABC):
 
         # This implementation of a hold explicitly requires fixed-rate turns,
         # even when a predictor was configured to make ordinary heading changes instantaneous.
+        # Substep the lateral integration independently of the predictor's configured
+        # timestep so that fix arrival and multiple subsequent hold phase boundaries
+        # can all be processed during one coarse prediction step.
         if aircraft.predictor_params.get("hold") is not None:
-            use_turn_model = True
+            full_steps = int(time_evolve // HOLD_MAX_INTEGRATION_STEP_s)
+            remainder = time_evolve - full_steps * HOLD_MAX_INTEGRATION_STEP_s
+            for _ in range(full_steps):
+                self.update_position_with_turn_model(aircraft, HOLD_MAX_INTEGRATION_STEP_s, wind_field)
+            if remainder > 0.0:
+                self.update_position_with_turn_model(aircraft, remainder, wind_field)
+            return
 
         if use_turn_model:
             self.update_position_with_turn_model(aircraft, time_evolve, wind_field)

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -645,7 +645,9 @@ class Predictor(ABC):
         }
         if phase in inbound_turn_phases:
             target_track = (
-                inbound_course_deg if phase == "turn_inbound" else aircraft.pos2d().bearing_to(target_pos)
+                inbound_course_deg
+                if phase in {"turn_inbound", "teardrop_turn_inbound"}
+                else aircraft.pos2d().bearing_to(target_pos)
             )
             if aircraft.heading_changing_to is None:
                 hold["phase"] = inbound_turn_phases[phase]

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -39,7 +39,7 @@ HOLD_TURN_PHASES = frozenset(
     }
 )
 HOLD_DIRECTION_TURN_PHASES = frozenset(
-    {"turn_outbound", "turn_inbound", "parallel_turn_inbound", "teardrop_turn_inbound"}
+    {"turn_outbound", "turn_inbound", "teardrop_turn_inbound"}
 )
 HOLD_TIMED_LEG_PHASES = frozenset({"outbound", "parallel_outbound", "teardrop_outbound"})
 
@@ -428,7 +428,9 @@ class Predictor(ABC):
             turn_direction: Literal["left", "right"] | None = None
 
             # If aircraft is flying a heading
-            if hold is not None and hold["phase"] in HOLD_DIRECTION_TURN_PHASES:
+            if hold is not None and hold["phase"] == "parallel_turn_inbound":
+                turn_direction = "left" if hold["turn_direction"] == "right" else "right"
+            elif hold is not None and hold["phase"] in HOLD_DIRECTION_TURN_PHASES:
                 turn_direction = hold["turn_direction"]
             elif (
                 aircraft.cleared_instructions.lateral_action is not None

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from abc import ABC, abstractmethod
-from math import degrees, radians, tan
+from math import cos, degrees, hypot, radians, tan
 from typing import Literal
 
 import numpy as np
@@ -531,6 +531,78 @@ class Predictor(ABC):
             return "parallel"
         return "direct"
 
+    @staticmethod
+    def ground_speed_for_track(
+        ground_track_deg: float,
+        horizontal_speed_kts: float,
+        wind_vector: WindVector | None,
+    ) -> float:
+        """Return groundspeed while wind-correcting onto a requested track."""
+        heading = heading_from_ground_track(ground_track_deg, horizontal_speed_kts, wind_vector)
+        ground_speed, _ = ground_speed_from_tas(horizontal_speed_kts, heading, wind_vector)
+        return ground_speed
+
+    def calculate_teardrop_entry_geometry(
+        self,
+        inbound_course_deg: float,
+        outbound_time_s: float,
+        turn_direction: Literal["left", "right"],
+        horizontal_speed_kts: float,
+        wind_vector: WindVector | None,
+    ) -> tuple[float, float, float]:
+        """Return racetrack width, teardrop distance, and teardrop time.
+
+        The teardrop leg is treated as the hypotenuse of a triangle whose
+        along-track edge is the established outbound leg and whose cross-track
+        edge is the displacement of a standard-rate 180-degree turn. All three
+        distances use wind-adjusted groundspeed on their respective tracks.
+        """
+        direction_sign = 1.0 if turn_direction == "right" else -1.0
+        cross_track_deg = (inbound_course_deg + direction_sign * 90.0) % 360.0
+        turn_time_s = 180.0 / HOLD_RATE_OF_TURN_s
+        full_steps = int(turn_time_s // HOLD_MAX_INTEGRATION_STEP_s)
+        remainder = turn_time_s - full_steps * HOLD_MAX_INTEGRATION_STEP_s
+        steps = [HOLD_MAX_INTEGRATION_STEP_s] * full_steps
+        if remainder > 0.0:
+            steps.append(remainder)
+
+        racetrack_width_nm = 0.0
+        elapsed_s = 0.0
+        for step_s in steps:
+            midpoint_track_deg = (
+                inbound_course_deg
+                + direction_sign * HOLD_RATE_OF_TURN_s * (elapsed_s + 0.5 * step_s)
+            ) % 360.0
+            ground_speed_kts = self.ground_speed_for_track(
+                midpoint_track_deg,
+                horizontal_speed_kts,
+                wind_vector,
+            )
+            distance_nm = ground_speed_kts * step_s / 3600.0
+            racetrack_width_nm += distance_nm * cos(radians(midpoint_track_deg - cross_track_deg))
+            elapsed_s += step_s
+        racetrack_width_nm = abs(racetrack_width_nm)
+
+        outbound_track_deg = (inbound_course_deg + 180.0) % 360.0
+        outbound_ground_speed_kts = self.ground_speed_for_track(
+            outbound_track_deg,
+            horizontal_speed_kts,
+            wind_vector,
+        )
+        straight_leg_distance_nm = outbound_ground_speed_kts * outbound_time_s / 3600.0
+        teardrop_distance_nm = hypot(straight_leg_distance_nm, racetrack_width_nm)
+
+        teardrop_track_deg = (
+            outbound_track_deg - direction_sign * HOLD_TEARDROP_ANGLE_deg
+        ) % 360.0
+        teardrop_ground_speed_kts = self.ground_speed_for_track(
+            teardrop_track_deg,
+            horizontal_speed_kts,
+            wind_vector,
+        )
+        teardrop_time_s = teardrop_distance_nm * 3600.0 / teardrop_ground_speed_kts
+        return racetrack_width_nm, teardrop_distance_nm, teardrop_time_s
+
     def update_hold_guidance(
         self,
         aircraft: Aircraft,
@@ -600,6 +672,17 @@ class Predictor(ABC):
                 hold["phase"] = next_phase
                 if phase in {"turn_outbound", "teardrop_turn_outbound"}:
                     hold["phase_elapsed"] = 0.0
+                if phase == "teardrop_turn_outbound":
+                    width_nm, distance_nm, time_s = self.calculate_teardrop_entry_geometry(
+                        inbound_course_deg,
+                        hold["outbound_time_s"],
+                        hold["turn_direction"],
+                        horizontal_speed_kts,
+                        wind_vector,
+                    )
+                    hold["racetrack_width_nm"] = width_nm
+                    hold["teardrop_outbound_distance_nm"] = distance_nm
+                    hold["teardrop_outbound_time_s"] = time_s
                 aircraft.heading = heading_from_ground_track(target_track, horizontal_speed_kts, wind_vector)
             else:
                 aircraft.heading_changing_to = heading_from_ground_track(
@@ -610,7 +693,10 @@ class Predictor(ABC):
         timed_leg_phases = {
             "outbound": (hold["outbound_time_s"], "turn_inbound"),
             "parallel_outbound": (HOLD_ENTRY_TIME_s, "parallel_turn_inbound"),
-            "teardrop_outbound": (HOLD_ENTRY_TIME_s, "teardrop_turn_inbound"),
+            "teardrop_outbound": (
+                hold.get("teardrop_outbound_time_s", HOLD_ENTRY_TIME_s),
+                "teardrop_turn_inbound",
+            ),
         }
         if phase in timed_leg_phases:
             leg_time_s, next_phase = timed_leg_phases[phase]

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from abc import ABC, abstractmethod
-from math import cos, degrees, hypot, radians, tan
+from math import atan2, cos, degrees, hypot, radians, tan
 from typing import Literal
 
 import numpy as np
@@ -25,11 +25,8 @@ DEFAULT_RATE_OF_TURN = 1.5
 # configured rate for ordinary heading changes.  According to ICAO 8168 section 2.1.2, all turns
 # shall be made at a bank angle of 25° or at a rate of 3° per second, whichever requires the lesser bank.
 HOLD_RATE_OF_TURN_s = 3.0
-# Parallel entry timing starts when the holding fix is crossed. Teardrop entry
-# timing starts after the initial turn so that its outbound track is flown
-# straight for the full entry time.
+# Parallel entry timing starts when the holding fix is crossed.
 HOLD_ENTRY_TIME_s = 60.0
-HOLD_TEARDROP_ANGLE_deg = 30.0
 # Hold guidance can change phase at the fix, at the end of a turn, or at the
 # end of a timed leg. Limit its lateral integration step so a coarse predictor
 # timestep cannot skip those transitions or apply one phase for the full step.
@@ -475,10 +472,14 @@ class Predictor(ABC):
 
             new_bearing = (current_bearing + delta_phi) % 360
 
-            # del_phi_a is the change in bearing needed to reach the target bearing
-            del_phi_a = abs(target_bearing - current_bearing)
-            if del_phi_a > 180:
-                del_phi_a = 360 - del_phi_a
+            # Measure the remaining angle in the commanded direction. This is
+            # important for a teardrop entry, whose same-direction turn back
+            # inbound is normally greater than 180 degrees.
+            del_phi_a = (
+                (current_bearing - target_bearing) % 360.0
+                if turn_direction == "left"
+                else (target_bearing - current_bearing) % 360.0
+            )
 
             # If we'll overshoot the target bearing, set heading directly from target bearing
             if abs(delta_phi) >= del_phi_a:
@@ -549,15 +550,20 @@ class Predictor(ABC):
         turn_direction: Literal["left", "right"],
         horizontal_speed_kts: float,
         wind_vector: WindVector | None,
-    ) -> tuple[float, float, float]:
-        """Return racetrack width, teardrop distance, and teardrop time.
+    ) -> tuple[float, float, float, float]:
+        """Return racetrack width, teardrop turn-start distance, track, and time.
 
-        The teardrop leg is treated as the hypotenuse of a triangle whose
+        The nominal teardrop leg is the hypotenuse of a triangle whose
         along-track edge is the established outbound leg and whose cross-track
-        edge is the displacement of a standard-rate 180-degree turn. All three
-        distances use wind-adjusted groundspeed on their respective tracks.
+        edge is the displacement of a standard-rate 180-degree turn. The
+        along-track displacement of that turn is included because it need not
+        cancel in wind. The actual turn starts before the nominal tangent point:
+        its distance is shortened by the amount needed for the finite-radius
+        return turn to finish on the inbound centreline. All distances use
+        wind-adjusted groundspeed on their respective tracks.
         """
         direction_sign = 1.0 if turn_direction == "right" else -1.0
+        outbound_track_deg = (inbound_course_deg + 180.0) % 360.0
         cross_track_deg = (inbound_course_deg + direction_sign * 90.0) % 360.0
         turn_time_s = 180.0 / HOLD_RATE_OF_TURN_s
         full_steps = int(turn_time_s // HOLD_MAX_INTEGRATION_STEP_s)
@@ -567,6 +573,7 @@ class Predictor(ABC):
             steps.append(remainder)
 
         racetrack_width_nm = 0.0
+        turn_along_track_nm = 0.0
         elapsed_s = 0.0
         for step_s in steps:
             midpoint_track_deg = (
@@ -580,28 +587,58 @@ class Predictor(ABC):
             )
             distance_nm = ground_speed_kts * step_s / 3600.0
             racetrack_width_nm += distance_nm * cos(radians(midpoint_track_deg - cross_track_deg))
+            turn_along_track_nm += distance_nm * cos(radians(midpoint_track_deg - outbound_track_deg))
             elapsed_s += step_s
         racetrack_width_nm = abs(racetrack_width_nm)
 
-        outbound_track_deg = (inbound_course_deg + 180.0) % 360.0
         outbound_ground_speed_kts = self.ground_speed_for_track(
             outbound_track_deg,
             horizontal_speed_kts,
             wind_vector,
         )
         straight_leg_distance_nm = outbound_ground_speed_kts * outbound_time_s / 3600.0
-        teardrop_distance_nm = hypot(straight_leg_distance_nm, racetrack_width_nm)
+        along_track_distance_nm = straight_leg_distance_nm + turn_along_track_nm
+        tangent_distance_nm = hypot(along_track_distance_nm, racetrack_width_nm)
 
-        teardrop_track_deg = (
-            outbound_track_deg - direction_sign * HOLD_TEARDROP_ANGLE_deg
-        ) % 360.0
+        teardrop_angle_deg = degrees(atan2(racetrack_width_nm, along_track_distance_nm))
+        teardrop_track_deg = (outbound_track_deg - direction_sign * teardrop_angle_deg) % 360.0
+        turn_back_time_s = (180.0 + teardrop_angle_deg) / HOLD_RATE_OF_TURN_s
+        full_steps = int(turn_back_time_s // HOLD_MAX_INTEGRATION_STEP_s)
+        remainder = turn_back_time_s - full_steps * HOLD_MAX_INTEGRATION_STEP_s
+        turn_back_steps = [HOLD_MAX_INTEGRATION_STEP_s] * full_steps
+        if remainder > 0.0:
+            turn_back_steps.append(remainder)
+
+        turn_back_cross_track_nm = 0.0
+        elapsed_s = 0.0
+        for step_s in turn_back_steps:
+            midpoint_track_deg = (
+                teardrop_track_deg
+                + direction_sign * HOLD_RATE_OF_TURN_s * (elapsed_s + 0.5 * step_s)
+            ) % 360.0
+            ground_speed_kts = self.ground_speed_for_track(
+                midpoint_track_deg,
+                horizontal_speed_kts,
+                wind_vector,
+            )
+            distance_nm = ground_speed_kts * step_s / 3600.0
+            turn_back_cross_track_nm += distance_nm * cos(radians(midpoint_track_deg - cross_track_deg))
+            elapsed_s += step_s
+
+        entry_cross_track_per_nm = cos(radians(teardrop_track_deg - cross_track_deg))
+        turn_start_distance_nm = -turn_back_cross_track_nm / entry_cross_track_per_nm
+        teardrop_distance_nm = (
+            min(tangent_distance_nm, turn_start_distance_nm)
+            if turn_start_distance_nm > 0.0
+            else tangent_distance_nm
+        )
         teardrop_ground_speed_kts = self.ground_speed_for_track(
             teardrop_track_deg,
             horizontal_speed_kts,
             wind_vector,
         )
         teardrop_time_s = teardrop_distance_nm * 3600.0 / teardrop_ground_speed_kts
-        return racetrack_width_nm, teardrop_distance_nm, teardrop_time_s
+        return racetrack_width_nm, teardrop_distance_nm, teardrop_track_deg, teardrop_time_s
 
     def update_hold_guidance(
         self,
@@ -634,6 +671,20 @@ class Predictor(ABC):
                         hold["turn_direction"],
                     )
                     hold["entry_type"] = entry_type
+                    if entry_type == "teardrop":
+                        width_nm, distance_nm, track_deg, time_s = self.calculate_teardrop_entry_geometry(
+                            hold["inbound_course_deg"],
+                            hold["outbound_time_s"],
+                            hold["turn_direction"],
+                            horizontal_speed_kts,
+                            wind_vector,
+                        )
+                        turn_pos = target_pos.forward(distance_nm, track_deg)
+                        hold["racetrack_width_nm"] = width_nm
+                        hold["teardrop_outbound_distance_nm"] = distance_nm
+                        hold["teardrop_entry_track_deg"] = track_deg
+                        hold["teardrop_fix_to_turn_time_s"] = time_s
+                        hold["teardrop_turn_location"] = [turn_pos.lat, turn_pos.lon]
                     hold["phase"] = {
                         "direct": "turn_outbound",
                         "parallel": "parallel_turn_outbound",
@@ -653,18 +704,18 @@ class Predictor(ABC):
 
         inbound_course_deg = hold["inbound_course_deg"]
         outbound_track = (inbound_course_deg + 180.0) % 360.0
+        teardrop_turn_location = hold.get("teardrop_turn_location")
+        teardrop_turn_pos = None if teardrop_turn_location is None else Pos2D(*teardrop_turn_location)
+        teardrop_target_track = (
+            hold.get("teardrop_entry_track_deg", outbound_track)
+            if teardrop_turn_pos is None
+            else aircraft.pos2d().bearing_to(teardrop_turn_pos)
+        )
 
         outbound_turn_phases = {
             "turn_outbound": (outbound_track, "outbound"),
             "parallel_turn_outbound": (outbound_track, "parallel_outbound"),
-            "teardrop_turn_outbound": (
-                (
-                    outbound_track
-                    - (HOLD_TEARDROP_ANGLE_deg if hold["turn_direction"] == "right" else -HOLD_TEARDROP_ANGLE_deg)
-                )
-                % 360.0,
-                "teardrop_outbound",
-            ),
+            "teardrop_turn_outbound": (teardrop_target_track, "teardrop_outbound"),
         }
         if phase in outbound_turn_phases:
             target_track, next_phase = outbound_turn_phases[phase]
@@ -673,16 +724,18 @@ class Predictor(ABC):
                 if phase in {"turn_outbound", "teardrop_turn_outbound"}:
                     hold["phase_elapsed"] = 0.0
                 if phase == "teardrop_turn_outbound":
-                    width_nm, distance_nm, time_s = self.calculate_teardrop_entry_geometry(
-                        inbound_course_deg,
-                        hold["outbound_time_s"],
-                        hold["turn_direction"],
+                    if teardrop_turn_pos is None:
+                        raise ValueError("Teardrop entry has no turn location")
+                    target_track = aircraft.pos2d().bearing_to(teardrop_turn_pos)
+                    remaining_distance_nm = aircraft.pos2d().distance(teardrop_turn_pos)
+                    remaining_ground_speed_kts = self.ground_speed_for_track(
+                        target_track,
                         horizontal_speed_kts,
                         wind_vector,
                     )
-                    hold["racetrack_width_nm"] = width_nm
-                    hold["teardrop_outbound_distance_nm"] = distance_nm
-                    hold["teardrop_outbound_time_s"] = time_s
+                    hold["teardrop_outbound_track_deg"] = target_track
+                    hold["teardrop_outbound_remaining_distance_nm"] = remaining_distance_nm
+                    hold["teardrop_outbound_time_s"] = remaining_distance_nm * 3600.0 / remaining_ground_speed_kts
                 aircraft.heading = heading_from_ground_track(target_track, horizontal_speed_kts, wind_vector)
             else:
                 aircraft.heading_changing_to = heading_from_ground_track(
@@ -703,11 +756,7 @@ class Predictor(ABC):
             target_track = (
                 outbound_track
                 if phase != "teardrop_outbound"
-                else (
-                    outbound_track
-                    - (HOLD_TEARDROP_ANGLE_deg if hold["turn_direction"] == "right" else -HOLD_TEARDROP_ANGLE_deg)
-                )
-                % 360.0
+                else teardrop_target_track
             )
             if hold["phase_elapsed"] >= leg_time_s:
                 hold["phase"] = next_phase

--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -25,7 +25,9 @@ DEFAULT_RATE_OF_TURN = 1.5
 # configured rate for ordinary heading changes.  According to ICAO 8168 section 2.1.2, all turns
 # shall be made at a bank angle of 25° or at a rate of 3° per second, whichever requires the lesser bank.
 HOLD_RATE_OF_TURN_s = 3.0
-HOLD_ENTRY_LEG_TIME_s = 60.0
+# Parallel and teardrop entry timing starts when the holding fix is crossed,
+# including the initial turn onto the entry's outbound track.
+HOLD_ENTRY_TIME_s = 60.0
 HOLD_TEARDROP_ANGLE_deg = 30.0
 
 HOLD_TURN_PHASES = frozenset(
@@ -41,7 +43,15 @@ HOLD_TURN_PHASES = frozenset(
 HOLD_DIRECTION_TURN_PHASES = frozenset(
     {"turn_outbound", "turn_inbound", "teardrop_turn_inbound"}
 )
-HOLD_TIMED_LEG_PHASES = frozenset({"outbound", "parallel_outbound", "teardrop_outbound"})
+HOLD_TIMED_LEG_PHASES = frozenset(
+    {
+        "outbound",
+        "parallel_turn_outbound",
+        "parallel_outbound",
+        "teardrop_turn_outbound",
+        "teardrop_outbound",
+    }
+)
 
 # Threshold difference (in degrees) between requested heading and actual heading. Below this threshold
 # the heading is automatically updated, without an explicit use of a turn model.
@@ -574,7 +584,8 @@ class Predictor(ABC):
             target_track, next_phase = outbound_turn_phases[phase]
             if aircraft.heading_changing_to is None and not entered_turn:
                 hold["phase"] = next_phase
-                hold["phase_elapsed"] = 0.0
+                if phase == "turn_outbound":
+                    hold["phase_elapsed"] = 0.0
                 aircraft.heading = heading_from_ground_track(target_track, horizontal_speed_kts, wind_vector)
             else:
                 aircraft.heading_changing_to = heading_from_ground_track(
@@ -584,8 +595,8 @@ class Predictor(ABC):
 
         timed_leg_phases = {
             "outbound": (hold["outbound_time_s"], "turn_inbound"),
-            "parallel_outbound": (HOLD_ENTRY_LEG_TIME_s, "parallel_turn_inbound"),
-            "teardrop_outbound": (HOLD_ENTRY_LEG_TIME_s, "teardrop_turn_inbound"),
+            "parallel_outbound": (HOLD_ENTRY_TIME_s, "parallel_turn_inbound"),
+            "teardrop_outbound": (HOLD_ENTRY_TIME_s, "teardrop_turn_inbound"),
         }
         if phase in timed_leg_phases:
             leg_time_s, next_phase = timed_leg_phases[phase]

--- a/bluebird-dt/bluebird_dt/utility/clearance.py
+++ b/bluebird-dt/bluebird_dt/utility/clearance.py
@@ -643,6 +643,34 @@ def which_way(current: float, cleared: float) -> Literal["left", "right"]:
     return "right"
 
 
+def hold_phraseology(value: HoldParameters, voice: bool = False) -> list[str]:
+    """Build standard hold phraseology from validated hold parameters."""
+    minutes = f"{value.outbound_time_s / 60.0:g}"
+    location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"
+    compass_directions = ("north", "northeast", "east", "southeast", "south", "southwest", "west", "northwest")
+    outbound_course_deg = (value.inbound_course_deg + 180.0) % 360.0
+    direction_index = int((outbound_course_deg + 22.5) // 45.0) % len(compass_directions)
+    holding_direction = compass_directions[direction_index]
+    inbound_course = f"{value.inbound_course_deg:g}"
+    leg_length = spell_phonetically(minutes) if voice else minutes
+    spoken_course = spell_phonetically(inbound_course) if voice else inbound_course
+    leg_unit = "minute" if minutes == "1" else "minutes"
+    return [
+        "hold",
+        holding_direction,
+        "of",
+        location,
+        "on course",
+        spoken_course,
+        "for",
+        leg_length,
+        leg_unit,
+        "with",
+        value.turn_direction,
+        "turns",
+    ]
+
+
 def text_phraseology(action: Action, environment: Environment) -> ClearanceAndResponse:
     """
     Generate clearance that would be issued for an action with matching response
@@ -767,12 +795,7 @@ def text_phraseology(action: Action, environment: Environment) -> ClearanceAndRe
 
         case "route_direct_to,hold_at_location":
             assert isinstance(value, HoldParameters)
-            minutes = f"{value.outbound_time_s / 60.0:g}"
-            location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"
-            clearance_parts.extend(["hold at", location])
-            if value.inbound_course_deg is not None:
-                clearance_parts.extend(["inbound course", f"{value.inbound_course_deg:g}"])
-            clearance_parts.extend([value.turn_direction, "hand", "outbound time", minutes, "minutes"])
+            clearance_parts.extend(hold_phraseology(value))
 
         case "change_cas_to":
             clearance_parts.extend(["fly speed", str(value), "knots"])
@@ -1010,12 +1033,7 @@ def voice_phraseology(action: Action, environment: Environment) -> ClearanceAndR
 
         case "route_direct_to,hold_at_location":
             assert isinstance(value, HoldParameters)
-            minutes = f"{value.outbound_time_s / 60.0:g}"
-            location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"
-            clearance_parts.extend(["hold at", location])
-            if value.inbound_course_deg is not None:
-                clearance_parts.extend(["inbound course", f"{value.inbound_course_deg:g}"])
-            clearance_parts.extend([value.turn_direction, "hand", "outbound time", minutes, "minutes"])
+            clearance_parts.extend(hold_phraseology(value, voice=True))
 
         case "change_cas_to":
             clearance_parts.extend(["speed", spell_phonetically(str(value)), "knots"])

--- a/bluebird-dt/bluebird_dt/utility/clearance.py
+++ b/bluebird-dt/bluebird_dt/utility/clearance.py
@@ -769,9 +769,10 @@ def text_phraseology(action: Action, environment: Environment) -> ClearanceAndRe
             assert isinstance(value, HoldParameters)
             minutes = f"{value.outbound_time_s / 60.0:g}"
             location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"
-            clearance_parts.extend(
-                ["hold at", location, value.turn_direction, "hand", "outbound time", minutes, "minutes"]
-            )
+            clearance_parts.extend(["hold at", location])
+            if value.inbound_course_deg is not None:
+                clearance_parts.extend(["inbound course", f"{value.inbound_course_deg:g}"])
+            clearance_parts.extend([value.turn_direction, "hand", "outbound time", minutes, "minutes"])
 
         case "change_cas_to":
             clearance_parts.extend(["fly speed", str(value), "knots"])
@@ -1011,9 +1012,10 @@ def voice_phraseology(action: Action, environment: Environment) -> ClearanceAndR
             assert isinstance(value, HoldParameters)
             minutes = f"{value.outbound_time_s / 60.0:g}"
             location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"
-            clearance_parts.extend(
-                ["hold at", location, value.turn_direction, "hand", "outbound time", minutes, "minutes"]
-            )
+            clearance_parts.extend(["hold at", location])
+            if value.inbound_course_deg is not None:
+                clearance_parts.extend(["inbound course", f"{value.inbound_course_deg:g}"])
+            clearance_parts.extend([value.turn_direction, "hand", "outbound time", minutes, "minutes"])
 
         case "change_cas_to":
             clearance_parts.extend(["speed", spell_phonetically(str(value)), "knots"])

--- a/bluebird-dt/bluebird_dt/utility/clearance.py
+++ b/bluebird-dt/bluebird_dt/utility/clearance.py
@@ -648,10 +648,10 @@ def hold_phraseology(value: HoldParameters, voice: bool = False) -> list[str]:
     minutes = f"{value.outbound_time_s / 60.0:g}"
     location = value.fix or f"latitude {value.location[0]:g} longitude {value.location[1]:g}"
     compass_directions = ("north", "northeast", "east", "southeast", "south", "southwest", "west", "northwest")
-    outbound_course_deg = (value.inbound_course_deg + 180.0) % 360.0
-    direction_index = int((outbound_course_deg + 22.5) // 45.0) % len(compass_directions)
+    direction_index = int((value.hold_orientation_deg + 22.5) // 45.0) % len(compass_directions)
     holding_direction = compass_directions[direction_index]
-    inbound_course = f"{value.inbound_course_deg:g}"
+    inbound_course_deg = (value.hold_orientation_deg + 180.0) % 360.0
+    inbound_course = f"{inbound_course_deg:g}"
     leg_length = spell_phonetically(minutes) if voice else minutes
     spoken_course = spell_phonetically(inbound_course) if voice else inbound_course
     leg_unit = "minute" if minutes == "1" else "minutes"

--- a/bluebird-dt/tests/unit/core/conftest.py
+++ b/bluebird-dt/tests/unit/core/conftest.py
@@ -516,7 +516,7 @@ def make_action(kind: str) -> Action:
     if kind == "route_direct_to":
         value = random.choice([make_random_fix_name(), [make_random_fix_name()]])
     if kind == "route_direct_to,hold_at_location":
-        value = HoldAtFixParameters(fix=make_random_fix_name(), inbound_course_deg=make_random_heading() % 360.0)
+        value = HoldAtFixParameters(fix=make_random_fix_name(), hold_orientation_deg=make_random_heading() % 360.0)
     if kind == "change_heading_to":
         value = make_random_heading()
     if kind == "change_heading_to_by_direction":

--- a/bluebird-dt/tests/unit/core/conftest.py
+++ b/bluebird-dt/tests/unit/core/conftest.py
@@ -516,7 +516,7 @@ def make_action(kind: str) -> Action:
     if kind == "route_direct_to":
         value = random.choice([make_random_fix_name(), [make_random_fix_name()]])
     if kind == "route_direct_to,hold_at_location":
-        value = HoldAtFixParameters(fix=make_random_fix_name())
+        value = HoldAtFixParameters(fix=make_random_fix_name(), inbound_course_deg=make_random_heading() % 360.0)
     if kind == "change_heading_to":
         value = make_random_heading()
     if kind == "change_heading_to_by_direction":

--- a/bluebird-dt/tests/unit/core/test_action.py
+++ b/bluebird-dt/tests/unit/core/test_action.py
@@ -91,7 +91,12 @@ def test_hold_parameters_roundtrip():
     action = Action(
         callsign="AIR0",
         kind="route_direct_to,hold_at_location",
-        value={"fix": "FIX", "outbound_time_s": 60, "turn_direction": "left"},
+        value={
+            "fix": "FIX",
+            "inbound_course_deg": 270,
+            "outbound_time_s": 60,
+            "turn_direction": "left",
+        },
     )
 
     assert action == Action.from_json(action.to_json())
@@ -102,10 +107,12 @@ def test_hold_parameters_from_json_string():
     action = Action(
         callsign="AIR0",
         kind="route_direct_to,hold_at_location",
-        value='{"fix":"FIX","outbound_time_s":60,"turn_direction":"left"}',
+        value='{"fix":"FIX","inbound_course_deg":270,"outbound_time_s":60,"turn_direction":"left"}',
     )
 
-    assert action.value == HoldAtFixParameters(fix="FIX", outbound_time_s=60, turn_direction="left")
+    assert action.value == HoldAtFixParameters(
+        fix="FIX", inbound_course_deg=270, outbound_time_s=60, turn_direction="left"
+    )
 
 
 def test_coordinate_hold_parameters_roundtrip():
@@ -129,6 +136,8 @@ def test_coordinate_hold_parameters_roundtrip():
         {"fix": "FIX", "location": (50.0, -3.0)},
         {"location": (91.0, -3.0)},
         {"location": (50.0, -181.0)},
+        {"fix": "FIX", "inbound_course_deg": -1},
+        {"fix": "FIX", "inbound_course_deg": 360},
         {"fix": "FIX", "outbound_time_s": 0},
         {"fix": "FIX", "turn_direction": "straight"},
     ],

--- a/bluebird-dt/tests/unit/core/test_action.py
+++ b/bluebird-dt/tests/unit/core/test_action.py
@@ -30,7 +30,7 @@ def test_init_exceptions_from_str():
     "kind, value",
     [
         ("route_direct_to", "FIX"),
-        ("route_direct_to,hold_at_location", HoldAtFixParameters(fix="FIX")),
+        ("route_direct_to,hold_at_location", HoldAtFixParameters(fix="FIX", inbound_course_deg=0)),
         ("change_heading_to", 120),
         ("change_heading_by", -10),
         ("change_flight_level_to", 250),
@@ -119,7 +119,7 @@ def test_coordinate_hold_parameters_roundtrip():
     action = Action(
         callsign="AIR0",
         kind="route_direct_to,hold_at_location",
-        value={"location": (50.716667, -3.533333), "outbound_time_s": 60},
+        value={"location": (50.716667, -3.533333), "inbound_course_deg": 90, "outbound_time_s": 60},
     )
 
     assert action.value.location == (50.716667, -3.533333)
@@ -134,6 +134,7 @@ def test_coordinate_hold_parameters_roundtrip():
         {},
         {"fix": ""},
         {"fix": "FIX", "location": (50.0, -3.0)},
+        {"fix": "FIX"},
         {"location": (91.0, -3.0)},
         {"location": (50.0, -181.0)},
         {"fix": "FIX", "inbound_course_deg": -1},

--- a/bluebird-dt/tests/unit/core/test_action.py
+++ b/bluebird-dt/tests/unit/core/test_action.py
@@ -30,7 +30,7 @@ def test_init_exceptions_from_str():
     "kind, value",
     [
         ("route_direct_to", "FIX"),
-        ("route_direct_to,hold_at_location", HoldAtFixParameters(fix="FIX", inbound_course_deg=0)),
+        ("route_direct_to,hold_at_location", HoldAtFixParameters(fix="FIX", hold_orientation_deg=180)),
         ("change_heading_to", 120),
         ("change_heading_by", -10),
         ("change_flight_level_to", 250),
@@ -93,7 +93,7 @@ def test_hold_parameters_roundtrip():
         kind="route_direct_to,hold_at_location",
         value={
             "fix": "FIX",
-            "inbound_course_deg": 270,
+            "hold_orientation_deg": 90,
             "outbound_time_s": 60,
             "turn_direction": "left",
         },
@@ -107,11 +107,11 @@ def test_hold_parameters_from_json_string():
     action = Action(
         callsign="AIR0",
         kind="route_direct_to,hold_at_location",
-        value='{"fix":"FIX","inbound_course_deg":270,"outbound_time_s":60,"turn_direction":"left"}',
+        value='{"fix":"FIX","hold_orientation_deg":90,"outbound_time_s":60,"turn_direction":"left"}',
     )
 
     assert action.value == HoldAtFixParameters(
-        fix="FIX", inbound_course_deg=270, outbound_time_s=60, turn_direction="left"
+        fix="FIX", hold_orientation_deg=90, outbound_time_s=60, turn_direction="left"
     )
 
 
@@ -119,7 +119,7 @@ def test_coordinate_hold_parameters_roundtrip():
     action = Action(
         callsign="AIR0",
         kind="route_direct_to,hold_at_location",
-        value={"location": (50.716667, -3.533333), "inbound_course_deg": 90, "outbound_time_s": 60},
+        value={"location": (50.716667, -3.533333), "hold_orientation_deg": 270, "outbound_time_s": 60},
     )
 
     assert action.value.location == (50.716667, -3.533333)
@@ -137,10 +137,10 @@ def test_coordinate_hold_parameters_roundtrip():
         {"fix": "FIX"},
         {"location": (91.0, -3.0)},
         {"location": (50.0, -181.0)},
-        {"fix": "FIX", "inbound_course_deg": -1},
-        {"fix": "FIX", "inbound_course_deg": 360},
-        {"fix": "FIX", "outbound_time_s": 0},
-        {"fix": "FIX", "turn_direction": "straight"},
+        {"fix": "FIX", "hold_orientation_deg": -1},
+        {"fix": "FIX", "hold_orientation_deg": 360},
+        {"fix": "FIX", "hold_orientation_deg": 90, "outbound_time_s": 0},
+        {"fix": "FIX", "hold_orientation_deg": 90, "turn_direction": "straight"},
     ],
 )
 def test_invalid_hold_parameters(value: dict):

--- a/bluebird-dt/tests/unit/core/test_pilot.py
+++ b/bluebird-dt/tests/unit/core/test_pilot.py
@@ -262,7 +262,7 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
     hold_action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"fix": hold_fix, "outbound_time_s": 45, "turn_direction": "left"},
+        {"fix": hold_fix, "inbound_course_deg": 270, "outbound_time_s": 45, "turn_direction": "left"},
     )
 
     aircraft.pilot.receive_actions([hold_action], environment)
@@ -274,11 +274,12 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
             environment.airspace.fixes.places[hold_fix].lat,
             environment.airspace.fixes.places[hold_fix].lon,
         ],
+        "inbound_course_deg": 270.0,
         "outbound_time_s": 45.0,
         "turn_direction": "left",
         "phase": "direct_to_location",
         "phase_elapsed": 0.0,
-        "inbound_track": None,
+        "entry_type": None,
     }
     assert aircraft.on_route is False
 

--- a/bluebird-dt/tests/unit/core/test_pilot.py
+++ b/bluebird-dt/tests/unit/core/test_pilot.py
@@ -262,7 +262,7 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
     hold_action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"fix": hold_fix, "inbound_course_deg": 270, "outbound_time_s": 45, "turn_direction": "left"},
+        {"fix": hold_fix, "hold_orientation_deg": 90, "outbound_time_s": 45, "turn_direction": "left"},
     )
 
     aircraft.pilot.receive_actions([hold_action], environment)
@@ -295,7 +295,7 @@ def test_hold_rejects_unknown_fix(generate_simple_environment):
     action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"fix": "NOT_A_FIX", "inbound_course_deg": 0},
+        {"fix": "NOT_A_FIX", "hold_orientation_deg": 180},
     )
 
     aircraft.pilot.receive_actions([action], environment)
@@ -310,13 +310,14 @@ def test_hold_at_coordinate(generate_simple_environment):
     action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"location": location, "inbound_course_deg": 0},
+        {"location": location, "hold_orientation_deg": 180},
     )
 
     aircraft.pilot.process_lateral_actions(action, environment)
 
     assert aircraft.predictor_params["hold"]["fix"] is None
     assert aircraft.predictor_params["hold"]["location"] == list(location)
+    assert aircraft.predictor_params["hold"]["inbound_course_deg"] == 0.0
     assert aircraft.heading_changing_to == pytest.approx(aircraft.pos2d().bearing_to(Pos2D(*location)))
 
 

--- a/bluebird-dt/tests/unit/core/test_pilot.py
+++ b/bluebird-dt/tests/unit/core/test_pilot.py
@@ -292,7 +292,11 @@ def test_hold_action_and_lateral_cancellation(generate_simple_environment):
 def test_hold_rejects_unknown_fix(generate_simple_environment):
     environment = generate_simple_environment
     aircraft = environment.aircraft["AIR0"]
-    action = Action(aircraft.callsign, "route_direct_to,hold_at_location", {"fix": "NOT_A_FIX"})
+    action = Action(
+        aircraft.callsign,
+        "route_direct_to,hold_at_location",
+        {"fix": "NOT_A_FIX", "inbound_course_deg": 0},
+    )
 
     aircraft.pilot.receive_actions([action], environment)
     with pytest.raises(ValueError, match="Unknown holding fix"):
@@ -303,7 +307,11 @@ def test_hold_at_coordinate(generate_simple_environment):
     environment = generate_simple_environment
     aircraft = environment.aircraft["AIR0"]
     location = (51.25, -1.75)
-    action = Action(aircraft.callsign, "route_direct_to,hold_at_location", {"location": location})
+    action = Action(
+        aircraft.callsign,
+        "route_direct_to,hold_at_location",
+        {"location": location, "inbound_course_deg": 0},
+    )
 
     aircraft.pilot.process_lateral_actions(action, environment)
 

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -12,10 +12,17 @@ def test_repeating_standard_rate_hold(generate_simple_environment: Environment):
     aircraft.selected_instructions.cas = 360
     aircraft.cleared_instructions.cas = 360
     predictor = SimplePredictor(1.0, 2.0, fixes=environment.airspace.fixes)
+    hold_fix = environment.airspace.fixes.places["EARTH"]
+    inbound_course_deg = aircraft.pos2d().bearing_to(hold_fix)
     action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"fix": "EARTH", "outbound_time_s": 30, "turn_direction": "right"},
+        {
+            "fix": "EARTH",
+            "inbound_course_deg": inbound_course_deg,
+            "outbound_time_s": 30,
+            "turn_direction": "right",
+        },
     )
     aircraft.pilot.process_lateral_actions(action, environment)
 
@@ -82,11 +89,16 @@ def test_coordinate_hold_does_not_require_predictor_fixes(generate_simple_enviro
     aircraft.selected_instructions.cas = 360
     aircraft.cleared_instructions.cas = 360
     hold_position = environment.airspace.fixes.places["EARTH"]
+    inbound_course_deg = aircraft.pos2d().bearing_to(hold_position)
     predictor = SimplePredictor(1.0, 2.0, fixes=None)
     action = Action(
         aircraft.callsign,
         "route_direct_to,hold_at_location",
-        {"location": (hold_position.lat, hold_position.lon), "outbound_time_s": 30},
+        {
+            "location": (hold_position.lat, hold_position.lon),
+            "inbound_course_deg": inbound_course_deg,
+            "outbound_time_s": 30,
+        },
     )
     aircraft.pilot.process_lateral_actions(action, environment)
 

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -62,11 +62,13 @@ def test_hold_state_survives_aircraft_json_roundtrip(generate_simple_environment
     aircraft = generate_simple_environment.aircraft["AIR0"]
     aircraft.predictor_params["hold"] = {
         "fix": "EARTH",
+        "location": None,
+        "inbound_course_deg": 0.0,
         "outbound_time_s": 90.0,
         "turn_direction": "left",
         "phase": "outbound",
         "phase_elapsed": 12.0,
-        "inbound_track": 0.0,
+        "entry_type": "direct",
     }
 
     restored = aircraft.from_json(aircraft.to_json())
@@ -92,3 +94,143 @@ def test_coordinate_hold_does_not_require_predictor_fixes(generate_simple_enviro
         predictor.predict_aircraft(aircraft, 1.0, deepcopy_aircraft=False)
 
     assert aircraft.predictor_params["hold"]["phase"] != "direct_to_location"
+
+
+@pytest.mark.parametrize(
+    ("turn_direction", "arrival_track_deg", "expected_entry"),
+    [
+        ("right", 0.0, "direct"),
+        ("right", 225.0, "parallel"),
+        ("right", 135.0, "teardrop"),
+        ("left", 0.0, "direct"),
+        ("left", 135.0, "parallel"),
+        ("left", 225.0, "teardrop"),
+        ("right", 110.0, "direct"),
+        ("right", 180.0, "parallel"),
+        ("right", 290.0, "direct"),
+    ],
+)
+def test_select_hold_entry(
+    turn_direction: str,
+    arrival_track_deg: float,
+    expected_entry: str,
+):
+    assert SimplePredictor.select_hold_entry(arrival_track_deg, 0.0, turn_direction) == expected_entry
+
+
+@pytest.mark.parametrize(
+    ("turn_direction", "arrival_track_deg", "expected_entry", "expected_phase"),
+    [
+        ("right", 0.0, "direct", "turn_outbound"),
+        ("right", 225.0, "parallel", "parallel_turn_outbound"),
+        ("right", 135.0, "teardrop", "teardrop_turn_outbound"),
+        ("left", 135.0, "parallel", "parallel_turn_outbound"),
+        ("left", 225.0, "teardrop", "teardrop_turn_outbound"),
+    ],
+)
+def test_hold_starts_selected_entry(
+    generate_simple_environment: Environment,
+    turn_direction: str,
+    arrival_track_deg: float,
+    expected_entry: str,
+    expected_phase: str,
+):
+    environment = generate_simple_environment
+    aircraft = environment.aircraft["AIR0"]
+    hold_fix = environment.airspace.fixes.places["EARTH"]
+    predictor = SimplePredictor(1.0, 2.0, fixes=environment.airspace.fixes)
+    aircraft.pilot.process_lateral_actions(
+        Action(
+            aircraft.callsign,
+            "route_direct_to,hold_at_location",
+            {"fix": "EARTH", "inbound_course_deg": 0.0, "turn_direction": turn_direction},
+        ),
+        environment,
+    )
+    aircraft.lat = hold_fix.lat
+    aircraft.lon = hold_fix.lon
+    aircraft.heading = arrival_track_deg
+    aircraft.heading_changing_to = None
+
+    predictor.update_hold_guidance(
+        aircraft,
+        aircraft.predictor_params["hold"],
+        arrival_track_deg,
+        aircraft.selected_instructions.cas,
+        None,
+    )
+
+    assert aircraft.predictor_params["hold"]["entry_type"] == expected_entry
+    assert aircraft.predictor_params["hold"]["phase"] == expected_phase
+
+
+@pytest.mark.parametrize(
+    ("turn_direction", "relative_arrival_deg", "entry_type"),
+    [
+        ("right", 225.0, "parallel"),
+        ("right", 135.0, "teardrop"),
+        ("left", 225.0, "parallel"),
+        ("left", 135.0, "teardrop"),
+    ],
+)
+def test_non_direct_entry_joins_repeating_hold(
+    generate_simple_environment: Environment,
+    turn_direction: str,
+    relative_arrival_deg: float,
+    entry_type: str,
+):
+    environment = generate_simple_environment
+    aircraft = environment.aircraft["AIR0"]
+    aircraft.selected_instructions.cas = 360
+    aircraft.cleared_instructions.cas = 360
+    hold_fix = environment.airspace.fixes.places["EARTH"]
+    arrival_track_deg = aircraft.pos2d().bearing_to(hold_fix)
+    direction_sign = 1.0 if turn_direction == "right" else -1.0
+    inbound_course_deg = (arrival_track_deg - direction_sign * relative_arrival_deg) % 360.0
+    predictor = SimplePredictor(1.0, 2.0, fixes=environment.airspace.fixes)
+    aircraft.pilot.process_lateral_actions(
+        Action(
+            aircraft.callsign,
+            "route_direct_to,hold_at_location",
+            {
+                "fix": "EARTH",
+                "inbound_course_deg": inbound_course_deg,
+                "outbound_time_s": 30,
+                "turn_direction": turn_direction,
+            },
+        ),
+        environment,
+    )
+
+    transitions = []
+    previous_phase = aircraft.predictor_params["hold"]["phase"]
+    for elapsed_s in range(1, 901):
+        predictor.predict_aircraft(aircraft, 1.0, deepcopy_aircraft=False)
+        phase = aircraft.predictor_params["hold"]["phase"]
+        if phase != previous_phase:
+            transitions.append((phase, elapsed_s, aircraft.heading))
+            previous_phase = phase
+        if phase == "outbound":
+            break
+
+    phases = [phase for phase, _, _ in transitions]
+    assert phases == [
+        f"{entry_type}_turn_outbound",
+        f"{entry_type}_outbound",
+        f"{entry_type}_turn_inbound",
+        f"{entry_type}_inbound",
+        "turn_outbound",
+        "outbound",
+    ]
+    assert aircraft.predictor_params["hold"]["entry_type"] == entry_type
+    outbound_track_deg = (inbound_course_deg + 180.0) % 360.0
+    expected_entry_track_deg = (
+        outbound_track_deg
+        if entry_type == "parallel"
+        else (outbound_track_deg - direction_sign * 30.0) % 360.0
+    )
+    assert transitions[1][2] == pytest.approx(expected_entry_track_deg)
+    assert transitions[-1][2] == pytest.approx(outbound_track_deg)
+    entry_outbound_started_s = transitions[1][1]
+    entry_inbound_turn_started_s = transitions[2][1]
+    assert entry_inbound_turn_started_s - entry_outbound_started_s == 60

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -246,3 +246,6 @@ def test_non_direct_entry_joins_repeating_hold(
     entry_outbound_started_s = transitions[1][1]
     entry_inbound_turn_started_s = transitions[2][1]
     assert entry_inbound_turn_started_s - entry_outbound_started_s == 60
+    if entry_type == "parallel":
+        parallel_turn_delta_deg = (transitions[2][2] - expected_entry_track_deg + 180.0) % 360.0 - 180.0
+        assert parallel_turn_delta_deg * direction_sign < 0.0

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -286,8 +286,11 @@ def test_non_direct_entry_joins_repeating_hold(
     entry_started_s = transitions[0][1]
     entry_outbound_started_s = transitions[1][1]
     entry_inbound_turn_started_s = transitions[2][1]
-    assert entry_inbound_turn_started_s - entry_started_s == 60
-    assert entry_inbound_turn_started_s - entry_outbound_started_s < 60
     if entry_type == "parallel":
+        assert entry_inbound_turn_started_s - entry_started_s == 60
+        assert entry_inbound_turn_started_s - entry_outbound_started_s < 60
         parallel_turn_delta_deg = (transitions[2][2] - expected_entry_track_deg + 180.0) % 360.0 - 180.0
         assert parallel_turn_delta_deg * direction_sign < 0.0
+    else:
+        assert entry_inbound_turn_started_s - entry_outbound_started_s == 60
+        assert entry_inbound_turn_started_s - entry_started_s > 60

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -1,10 +1,12 @@
 from copy import deepcopy
 from itertools import pairwise
+from math import ceil, hypot, radians
 
 import pytest
 
-from bluebird_dt.core import Action, Environment, HoldAtFixParameters, HoldAtLocationParameters
+from bluebird_dt.core import Action, Environment, HoldAtFixParameters, HoldAtLocationParameters, WindVector
 from bluebird_dt.predictor import SimplePredictor
+from bluebird_dt.utility.convert import KT_TO_MPS
 
 
 def test_coarse_hold_timestep_matches_one_second_integration(generate_simple_environment: Environment):
@@ -140,6 +142,40 @@ def test_coordinate_hold_does_not_require_predictor_fixes(generate_simple_enviro
         predictor.predict_aircraft(aircraft, 1.0, deepcopy_aircraft=False)
 
     assert aircraft.predictor_params["hold"]["phase"] != "direct_to_location"
+
+
+def test_teardrop_entry_time_uses_racetrack_geometry_and_wind():
+    predictor = SimplePredictor(1.0, 2.0)
+    horizontal_speed_kts = 360.0
+    outbound_time_s = 60.0
+
+    width_nm, distance_nm, time_s = predictor.calculate_teardrop_entry_geometry(
+        inbound_course_deg=0.0,
+        outbound_time_s=outbound_time_s,
+        turn_direction="right",
+        horizontal_speed_kts=horizontal_speed_kts,
+        wind_vector=None,
+    )
+
+    expected_width_nm = 2.0 * (horizontal_speed_kts / 3600.0) / radians(3.0)
+    expected_straight_distance_nm = horizontal_speed_kts * outbound_time_s / 3600.0
+    assert width_nm == pytest.approx(expected_width_nm, rel=2e-4)
+    assert distance_nm == pytest.approx(hypot(expected_straight_distance_nm, expected_width_nm), rel=2e-4)
+    assert time_s == pytest.approx(distance_nm * 3600.0 / horizontal_speed_kts)
+    assert time_s > outbound_time_s
+
+    wind_vector = WindVector.from_polar(wind_speed=40.0 * KT_TO_MPS, wind_direction=90.0)
+    windy_width_nm, windy_distance_nm, windy_time_s = predictor.calculate_teardrop_entry_geometry(
+        inbound_course_deg=0.0,
+        outbound_time_s=outbound_time_s,
+        turn_direction="right",
+        horizontal_speed_kts=horizontal_speed_kts,
+        wind_vector=wind_vector,
+    )
+
+    assert windy_width_nm != pytest.approx(width_nm)
+    assert windy_distance_nm != pytest.approx(distance_nm)
+    assert windy_time_s != pytest.approx(time_s)
 
 
 @pytest.mark.parametrize(
@@ -292,5 +328,8 @@ def test_non_direct_entry_joins_repeating_hold(
         parallel_turn_delta_deg = (transitions[2][2] - expected_entry_track_deg + 180.0) % 360.0 - 180.0
         assert parallel_turn_delta_deg * direction_sign < 0.0
     else:
-        assert entry_inbound_turn_started_s - entry_outbound_started_s == 60
-        assert entry_inbound_turn_started_s - entry_started_s > 60
+        teardrop_time_s = aircraft.predictor_params["hold"]["teardrop_outbound_time_s"]
+        assert entry_inbound_turn_started_s - entry_outbound_started_s == ceil(teardrop_time_s)
+        assert aircraft.predictor_params["hold"]["racetrack_width_nm"] > 0.0
+        assert aircraft.predictor_params["hold"]["teardrop_outbound_distance_nm"] > 0.0
+        assert entry_inbound_turn_started_s - entry_started_s > teardrop_time_s

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -243,9 +243,11 @@ def test_non_direct_entry_joins_repeating_hold(
     )
     assert transitions[1][2] == pytest.approx(expected_entry_track_deg)
     assert transitions[-1][2] == pytest.approx(outbound_track_deg)
+    entry_started_s = transitions[0][1]
     entry_outbound_started_s = transitions[1][1]
     entry_inbound_turn_started_s = transitions[2][1]
-    assert entry_inbound_turn_started_s - entry_outbound_started_s == 60
+    assert entry_inbound_turn_started_s - entry_started_s == 60
+    assert entry_inbound_turn_started_s - entry_outbound_started_s < 60
     if entry_type == "parallel":
         parallel_turn_delta_deg = (transitions[2][2] - expected_entry_track_deg + 180.0) % 360.0 - 180.0
         assert parallel_turn_delta_deg * direction_sign < 0.0

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -1,9 +1,43 @@
+from copy import deepcopy
 from itertools import pairwise
 
 import pytest
 
 from bluebird_dt.core import Action, Environment, HoldAtFixParameters, HoldAtLocationParameters
 from bluebird_dt.predictor import SimplePredictor
+
+
+def test_coarse_hold_timestep_matches_one_second_integration(generate_simple_environment: Environment):
+    environment = generate_simple_environment
+    aircraft = environment.aircraft["AIR0"]
+    aircraft.selected_instructions.cas = 360
+    aircraft.cleared_instructions.cas = 360
+    hold_fix = environment.airspace.fixes.places["EARTH"]
+    inbound_course_deg = aircraft.pos2d().bearing_to(hold_fix)
+    aircraft.pilot.process_lateral_actions(
+        Action(
+            aircraft.callsign,
+            "route_direct_to,hold_at_location",
+            HoldAtFixParameters(
+                fix="EARTH",
+                hold_orientation_deg=(inbound_course_deg + 180.0) % 360.0,
+                outbound_time_s=30,
+            ),
+        ),
+        environment,
+    )
+    coarse_aircraft = deepcopy(aircraft)
+    fine_aircraft = deepcopy(aircraft)
+    coarse_predictor = SimplePredictor(300.0, 2.0, fixes=environment.airspace.fixes)
+    fine_predictor = SimplePredictor(1.0, 2.0, fixes=environment.airspace.fixes)
+
+    coarse_predictor.predict_aircraft(coarse_aircraft, 300.0, deepcopy_aircraft=False)
+    for _ in range(300):
+        fine_predictor.predict_aircraft(fine_aircraft, 1.0, deepcopy_aircraft=False)
+
+    assert coarse_aircraft.predictor_params["hold"] == fine_aircraft.predictor_params["hold"]
+    assert coarse_aircraft.heading == pytest.approx(fine_aircraft.heading)
+    assert coarse_aircraft.pos2d().distance(fine_aircraft.pos2d()) == pytest.approx(0.0, abs=1e-6)
 
 
 def test_repeating_standard_rate_hold(generate_simple_environment: Environment):

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -1,10 +1,10 @@
 from copy import deepcopy
 from itertools import pairwise
-from math import ceil, hypot, radians
+from math import atan2, ceil, degrees, hypot, radians, tan
 
 import pytest
 
-from bluebird_dt.core import Action, Environment, HoldAtFixParameters, HoldAtLocationParameters, WindVector
+from bluebird_dt.core import Action, Environment, HoldAtFixParameters, HoldAtLocationParameters, Pos2D, WindVector
 from bluebird_dt.predictor import SimplePredictor
 from bluebird_dt.utility.convert import KT_TO_MPS
 
@@ -149,7 +149,7 @@ def test_teardrop_entry_time_uses_racetrack_geometry_and_wind():
     horizontal_speed_kts = 360.0
     outbound_time_s = 60.0
 
-    width_nm, distance_nm, time_s = predictor.calculate_teardrop_entry_geometry(
+    width_nm, distance_nm, track_deg, time_s = predictor.calculate_teardrop_entry_geometry(
         inbound_course_deg=0.0,
         outbound_time_s=outbound_time_s,
         turn_direction="right",
@@ -159,13 +159,20 @@ def test_teardrop_entry_time_uses_racetrack_geometry_and_wind():
 
     expected_width_nm = 2.0 * (horizontal_speed_kts / 3600.0) / radians(3.0)
     expected_straight_distance_nm = horizontal_speed_kts * outbound_time_s / 3600.0
+    expected_angle_deg = degrees(atan2(expected_width_nm, expected_straight_distance_nm))
+    expected_track_deg = 180.0 - expected_angle_deg
+    expected_turn_radius_nm = (horizontal_speed_kts / 3600.0) / radians(3.0)
+    expected_turn_start_distance_nm = expected_turn_radius_nm / tan(radians(expected_angle_deg / 2.0))
+    tangent_distance_nm = hypot(expected_straight_distance_nm, expected_width_nm)
     assert width_nm == pytest.approx(expected_width_nm, rel=2e-4)
-    assert distance_nm == pytest.approx(hypot(expected_straight_distance_nm, expected_width_nm), rel=2e-4)
+    assert distance_nm == pytest.approx(expected_turn_start_distance_nm, rel=2e-4)
+    assert distance_nm < tangent_distance_nm
+    assert track_deg == pytest.approx(expected_track_deg, rel=2e-4)
     assert time_s == pytest.approx(distance_nm * 3600.0 / horizontal_speed_kts)
     assert time_s > outbound_time_s
 
     wind_vector = WindVector.from_polar(wind_speed=40.0 * KT_TO_MPS, wind_direction=90.0)
-    windy_width_nm, windy_distance_nm, windy_time_s = predictor.calculate_teardrop_entry_geometry(
+    windy_width_nm, windy_distance_nm, windy_track_deg, windy_time_s = predictor.calculate_teardrop_entry_geometry(
         inbound_course_deg=0.0,
         outbound_time_s=outbound_time_s,
         turn_direction="right",
@@ -175,6 +182,7 @@ def test_teardrop_entry_time_uses_racetrack_geometry_and_wind():
 
     assert windy_width_nm != pytest.approx(width_nm)
     assert windy_distance_nm != pytest.approx(distance_nm)
+    assert windy_track_deg != pytest.approx(track_deg)
     assert windy_time_s != pytest.approx(time_s)
 
 
@@ -219,6 +227,8 @@ def test_hold_starts_selected_entry(
 ):
     environment = generate_simple_environment
     aircraft = environment.aircraft["AIR0"]
+    aircraft.selected_instructions.cas = 360
+    aircraft.cleared_instructions.cas = 360
     hold_fix = environment.airspace.fixes.places["EARTH"]
     predictor = SimplePredictor(1.0, 2.0, fixes=environment.airspace.fixes)
     aircraft.pilot.process_lateral_actions(
@@ -289,12 +299,16 @@ def test_non_direct_entry_joins_repeating_hold(
     )
 
     transitions = []
+    teardrop_turn_start_error_nm = None
     previous_phase = aircraft.predictor_params["hold"]["phase"]
     for elapsed_s in range(1, 901):
         predictor.predict_aircraft(aircraft, 1.0, deepcopy_aircraft=False)
         phase = aircraft.predictor_params["hold"]["phase"]
         if phase != previous_phase:
             transitions.append((phase, elapsed_s, aircraft.heading))
+            if phase == "teardrop_turn_inbound":
+                turn_location = aircraft.predictor_params["hold"]["teardrop_turn_location"]
+                teardrop_turn_start_error_nm = aircraft.pos2d().distance(Pos2D(*turn_location))
             previous_phase = phase
         if phase == "outbound":
             break
@@ -310,10 +324,8 @@ def test_non_direct_entry_joins_repeating_hold(
     ]
     assert aircraft.predictor_params["hold"]["entry_type"] == entry_type
     outbound_track_deg = (inbound_course_deg + 180.0) % 360.0
-    expected_entry_track_deg = (
-        outbound_track_deg
-        if entry_type == "parallel"
-        else (outbound_track_deg - direction_sign * 30.0) % 360.0
+    expected_entry_track_deg = aircraft.predictor_params["hold"].get(
+        "teardrop_outbound_track_deg", outbound_track_deg
     )
     assert transitions[1][2] == pytest.approx(expected_entry_track_deg)
     if entry_type == "teardrop":
@@ -322,6 +334,7 @@ def test_non_direct_entry_joins_repeating_hold(
     entry_started_s = transitions[0][1]
     entry_outbound_started_s = transitions[1][1]
     entry_inbound_turn_started_s = transitions[2][1]
+    entry_inbound_started_s = transitions[3][1]
     if entry_type == "parallel":
         assert entry_inbound_turn_started_s - entry_started_s == 60
         assert entry_inbound_turn_started_s - entry_outbound_started_s < 60
@@ -332,4 +345,7 @@ def test_non_direct_entry_joins_repeating_hold(
         assert entry_inbound_turn_started_s - entry_outbound_started_s == ceil(teardrop_time_s)
         assert aircraft.predictor_params["hold"]["racetrack_width_nm"] > 0.0
         assert aircraft.predictor_params["hold"]["teardrop_outbound_distance_nm"] > 0.0
+        assert teardrop_turn_start_error_nm is not None
+        assert teardrop_turn_start_error_nm < 0.25
+        assert entry_inbound_started_s - entry_inbound_turn_started_s > 60
         assert entry_inbound_turn_started_s - entry_started_s > teardrop_time_s

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -19,7 +19,7 @@ def test_repeating_standard_rate_hold(generate_simple_environment: Environment):
         "route_direct_to,hold_at_location",
         {
             "fix": "EARTH",
-            "inbound_course_deg": inbound_course_deg,
+            "hold_orientation_deg": (inbound_course_deg + 180.0) % 360.0,
             "outbound_time_s": 30,
             "turn_direction": "right",
         },
@@ -96,7 +96,7 @@ def test_coordinate_hold_does_not_require_predictor_fixes(generate_simple_enviro
         "route_direct_to,hold_at_location",
         {
             "location": (hold_position.lat, hold_position.lon),
-            "inbound_course_deg": inbound_course_deg,
+            "hold_orientation_deg": (inbound_course_deg + 180.0) % 360.0,
             "outbound_time_s": 30,
         },
     )
@@ -155,7 +155,7 @@ def test_hold_starts_selected_entry(
         Action(
             aircraft.callsign,
             "route_direct_to,hold_at_location",
-            {"fix": "EARTH", "inbound_course_deg": 0.0, "turn_direction": turn_direction},
+            {"fix": "EARTH", "hold_orientation_deg": 180.0, "turn_direction": turn_direction},
         ),
         environment,
     )
@@ -206,7 +206,7 @@ def test_non_direct_entry_joins_repeating_hold(
             "route_direct_to,hold_at_location",
             {
                 "fix": "EARTH",
-                "inbound_course_deg": inbound_course_deg,
+                "hold_orientation_deg": (inbound_course_deg + 180.0) % 360.0,
                 "outbound_time_s": 30,
                 "turn_direction": turn_direction,
             },

--- a/bluebird-dt/tests/unit/predictor/test_hold.py
+++ b/bluebird-dt/tests/unit/predictor/test_hold.py
@@ -280,6 +280,8 @@ def test_non_direct_entry_joins_repeating_hold(
         else (outbound_track_deg - direction_sign * 30.0) % 360.0
     )
     assert transitions[1][2] == pytest.approx(expected_entry_track_deg)
+    if entry_type == "teardrop":
+        assert transitions[3][2] == pytest.approx(inbound_course_deg)
     assert transitions[-1][2] == pytest.approx(outbound_track_deg)
     entry_started_s = transitions[0][1]
     entry_outbound_started_s = transitions[1][1]

--- a/bluebird-dt/tests/unit/utility/test_clearance.py
+++ b/bluebird-dt/tests/unit/utility/test_clearance.py
@@ -317,15 +317,20 @@ def test_hold_clearance(env: Environment):
     action = Action(
         "AIR0",
         "route_direct_to,hold_at_location",
-        {"fix": "ALPHA", "outbound_time_s": 90.0, "turn_direction": "right"},
+        {
+            "fix": "ALPHA",
+            "inbound_course_deg": 270,
+            "outbound_time_s": 90.0,
+            "turn_direction": "right",
+        },
     )
 
     assert_action_voice_and_text(
         action,
-        "AIR0 hold at ALPHA right hand outbound time 1.5 minutes",
-        "hold at ALPHA right hand outbound time 1.5 minutes AIR0",
-        "alpha india romeo zero hold at ALPHA right hand outbound time 1.5 minutes",
-        "hold at ALPHA right hand outbound time 1.5 minutes alpha india romeo zero",
+        "AIR0 hold at ALPHA inbound course 270 right hand outbound time 1.5 minutes",
+        "hold at ALPHA inbound course 270 right hand outbound time 1.5 minutes AIR0",
+        "alpha india romeo zero hold at ALPHA inbound course 270 right hand outbound time 1.5 minutes",
+        "hold at ALPHA inbound course 270 right hand outbound time 1.5 minutes alpha india romeo zero",
         env,
     )
 

--- a/bluebird-dt/tests/unit/utility/test_clearance.py
+++ b/bluebird-dt/tests/unit/utility/test_clearance.py
@@ -327,10 +327,10 @@ def test_hold_clearance(env: Environment):
 
     assert_action_voice_and_text(
         action,
-        "AIR0 hold at ALPHA inbound course 270 right hand outbound time 1.5 minutes",
-        "hold at ALPHA inbound course 270 right hand outbound time 1.5 minutes AIR0",
-        "alpha india romeo zero hold at ALPHA inbound course 270 right hand outbound time 1.5 minutes",
-        "hold at ALPHA inbound course 270 right hand outbound time 1.5 minutes alpha india romeo zero",
+        "AIR0 hold east of ALPHA on course 270 for 1.5 minutes with right turns",
+        "hold east of ALPHA on course 270 for 1.5 minutes with right turns AIR0",
+        "alpha india romeo zero hold east of ALPHA on course too seven zero for wun decimal five minutes with right turns",
+        "hold east of ALPHA on course too seven zero for wun decimal five minutes with right turns alpha india romeo zero",
         env,
     )
 
@@ -339,15 +339,15 @@ def test_coordinate_hold_clearance(env: Environment):
     action = Action(
         "AIR0",
         "route_direct_to,hold_at_location",
-        {"location": (50.716667, -3.533333), "outbound_time_s": 90.0},
+        {"location": (50.716667, -3.533333), "inbound_course_deg": 90, "outbound_time_s": 90.0},
     )
 
     assert_action_voice_and_text(
         action,
-        "AIR0 hold at latitude 50.7167 longitude -3.53333 right hand outbound time 1.5 minutes",
-        "hold at latitude 50.7167 longitude -3.53333 right hand outbound time 1.5 minutes AIR0",
-        "alpha india romeo zero hold at latitude 50.7167 longitude -3.53333 right hand outbound time 1.5 minutes",
-        "hold at latitude 50.7167 longitude -3.53333 right hand outbound time 1.5 minutes alpha india romeo zero",
+        "AIR0 hold west of latitude 50.7167 longitude -3.53333 on course 90 for 1.5 minutes with right turns",
+        "hold west of latitude 50.7167 longitude -3.53333 on course 90 for 1.5 minutes with right turns AIR0",
+        "alpha india romeo zero hold west of latitude 50.7167 longitude -3.53333 on course niner zero for wun decimal five minutes with right turns",
+        "hold west of latitude 50.7167 longitude -3.53333 on course niner zero for wun decimal five minutes with right turns alpha india romeo zero",
         env,
     )
 

--- a/bluebird-dt/tests/unit/utility/test_clearance.py
+++ b/bluebird-dt/tests/unit/utility/test_clearance.py
@@ -319,7 +319,7 @@ def test_hold_clearance(env: Environment):
         "route_direct_to,hold_at_location",
         {
             "fix": "ALPHA",
-            "inbound_course_deg": 270,
+            "hold_orientation_deg": 90,
             "outbound_time_s": 90.0,
             "turn_direction": "right",
         },
@@ -335,11 +335,31 @@ def test_hold_clearance(env: Environment):
     )
 
 
+def test_hold_clearance_calculates_inbound_course_from_orientation(env: Environment):
+    hold_fix_name = next(iter(env.airspace.fixes.places))
+    action = Action(
+        "AIR0",
+        "route_direct_to,hold_at_location",
+        {"fix": hold_fix_name, "hold_orientation_deg": 180, "outbound_time_s": 90.0},
+    )
+
+    assert_action_voice_and_text(
+        action,
+        f"AIR0 hold south of {hold_fix_name} on course 0 for 1.5 minutes with right turns",
+        f"hold south of {hold_fix_name} on course 0 for 1.5 minutes with right turns AIR0",
+        f"alpha india romeo zero hold south of {hold_fix_name} "
+        "on course zero for wun decimal five minutes with right turns",
+        f"hold south of {hold_fix_name} on course zero for wun decimal five minutes "
+        "with right turns alpha india romeo zero",
+        env,
+    )
+
+
 def test_coordinate_hold_clearance(env: Environment):
     action = Action(
         "AIR0",
         "route_direct_to,hold_at_location",
-        {"location": (50.716667, -3.533333), "inbound_course_deg": 90, "outbound_time_s": 90.0},
+        {"location": (50.716667, -3.533333), "hold_orientation_deg": 270, "outbound_time_s": 90.0},
     )
 
     assert_action_voice_and_text(


### PR DESCRIPTION
## Summary

- add direct, parallel, and teardrop entries for holds whose orientation is independent of the arrival track
- support standard hold phraseology and explicit outbound orientation
- make entry and racetrack guidance robust to wind and coarse predictor timesteps
- derive teardrop timing from racetrack geometry and lead the return turn for its finite turn radius

## Testing

- `uv run pytest bluebird-dt/tests/unit/predictor` (169 passed)
- `uv run ruff check bluebird-dt/bluebird_dt/predictor/predictor.py bluebird-dt/tests/unit/predictor/test_hold.py`

## Base

This PR is based on `simple-hold` and contains the fuller hold-entry implementation.

## Demo 

Pictures from the corresponding [Starling PR](https://github.com/project-bluebird/Starling/pull/1928)

<img width="2550" height="1700" alt="hold_entries_xplus" src="https://github.com/user-attachments/assets/3002844e-1202-4e55-a442-7595ccf37555" />

<img width="2550" height="1700" alt="hold_entries_xplus" src="https://github.com/user-attachments/assets/4bec88e5-775c-4064-b223-225de098fa40" />



