### PR TITLE
chore: Remove docs dependency group from bluebird-dt

### DIFF
--- a/bluebird-dt/pyproject.toml
+++ b/bluebird-dt/pyproject.toml
@@ -41,13 +41,6 @@ notebook = [
   "jupyter>=1.1.1",
 ]
 
-docs = [
-  "mkdocs-macros-plugin>=1.3.9",
-  "mkdocs-material>=9.6.16",
-  "mkdocstrings[python]>=0.30.0",
-  "tomli>=2.2.1",
-]
-
 [project.urls]
 Documentation = "http://docs.projectbluebird.ai"
 Repository = "https://github.com/project-bluebird/BluebirdATC"

--- a/uv.lock
+++ b/uv.lock
@@ -8,10 +8,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [manifest]
 members = [
     "bluebird-api",

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "bluebird-api",
@@ -282,12 +286,6 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
-docs = [
-    { name = "mkdocs-macros-plugin" },
-    { name = "mkdocs-material" },
-    { name = "mkdocstrings", extra = ["python"] },
-    { name = "tomli" },
-]
 notebook = [
     { name = "jupyter" },
 ]
@@ -318,12 +316,6 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0,<8.0.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0,<4.0.0" },
     { name = "ruff", specifier = ">=0.15.22,<0.16" },
-]
-docs = [
-    { name = "mkdocs-macros-plugin", specifier = ">=1.3.9" },
-    { name = "mkdocs-material", specifier = ">=9.6.16" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.30.0" },
-    { name = "tomli", specifier = ">=2.2.1" },
 ]
 notebook = [{ name = "jupyter", specifier = ">=1.1.1" }]
 


### PR DESCRIPTION
This should not be required given that the docs is now within a separate package