### PR TITLE
fix: Stop aircraft orbiting the last fix on their route

### DIFF
--- a/bluebird-dt/bluebird_dt/predictor/predictor.py
+++ b/bluebird-dt/bluebird_dt/predictor/predictor.py
@@ -336,8 +336,17 @@ class Predictor(ABC):
                 aircraft.predictor_params["turn_radius"] = turn_radius
 
             if aircraft.next_fix_index == len(aircraft.flight_plan.route.current) - 1:
-                # Next fix is the last one, so just use proximity threshold to check if we've reached it
-                if distance_to_fix <= self.fix_proximity_threshold:
+                # Next fix is the last one, so use the proximity threshold to check if we've reached it. With no
+                # following fix to sequence onto, an aircraft that cannot turn tightly enough onto it would
+                # circle it forever, so also stop once it has flown past. distance_to_abeam is negative beyond
+                # the fix, and None when the fix is further off track than the turn diameter, i.e. reachable.
+                turn_radius = aircraft.predictor_params.get("turn_radius")
+                distance_to_abeam = (
+                    None if turn_radius is None else aircraft.distance_to_abeam(target_pos, radius=2 * turn_radius)
+                )
+                has_passed_fix = distance_to_abeam is not None and distance_to_abeam < 0
+
+                if distance_to_fix <= self.fix_proximity_threshold or has_passed_fix:
                     # Aircraft has reached end of route so is no longer route-following
                     aircraft.next_fix_index = None
                     aircraft.on_route = False

--- a/bluebird-dt/tests/unit/predictor/test_predictor.py
+++ b/bluebird-dt/tests/unit/predictor/test_predictor.py
@@ -1,0 +1,92 @@
+"""Tests for route fix sequencing in the shared turn model (Predictor.update_position_with_turn_model)."""
+
+import pytest
+
+from bluebird_dt.core import Aircraft, Fixes, FlightPlan, Pos2D, Route
+from bluebird_dt.predictor import LinearPredictor
+
+# An approach with a 98 degree turn at the second to last fix and only 4 nmi of final leg
+# to run, which an aircraft with a large turn radius cannot fly.
+SHARP_APPROACH = {
+    "ENTRY": Pos2D(2.33235, -2.433833),
+    "TURN": Pos2D(2.526833, -2.638767),
+    "CORNER": Pos2D(2.597317, -2.649033),
+    "END": Pos2D(2.597217, -2.581667),
+}
+
+
+def fly(
+    route: list[str], fixes: dict[str, Pos2D], heading: float, cas: float, rate_of_turn: float, seconds: int = 3600
+) -> Aircraft:
+    """Fly an aircraft from the first fix of its route until it stops route following.
+
+    Speeds are held at ``cas`` and the rate of turn is fixed, so the turn radius is exactly
+    ``cas / (radians(rate_of_turn) * 3600)`` and the test does not depend on performance data.
+    """
+
+    start = fixes[route[0]]
+    aircraft = Aircraft(
+        lat=start.lat,
+        lon=start.lon,
+        fl=220.0,
+        heading=heading,
+        flight_plan=FlightPlan(Route(route)),
+        callsign="TEST1",
+        selected_fl=220,
+        aircraft_type="A320",
+        rate_of_turn=rate_of_turn,
+    )
+    aircraft.next_fix_index = 1
+    aircraft.on_route = True
+    aircraft.cleared_instructions.cas = cas
+    aircraft.selected_instructions.cas = cas
+
+    predictor = LinearPredictor(dt=1.0, fix_proximity_threshold=2.0, fixes=Fixes(fixes), use_cas_as_tas=True)
+
+    for _ in range(seconds):
+        predictor.predict_aircraft(aircraft, 1.0, deepcopy_aircraft=False)
+        if not aircraft.on_route:
+            break
+
+    return aircraft
+
+
+def test_aircraft_does_not_orbit_an_unflyable_last_fix():
+    """
+    An aircraft that cannot make the turn onto its last fix stops route following rather than circling it.
+    """
+
+    # 450 kt at 1.5 deg/s gives a ~4.8 nmi turn radius against a 4 nmi final leg.
+    aircraft = fly(["ENTRY", "TURN", "CORNER", "END"], SHARP_APPROACH, heading=313.0, cas=450.0, rate_of_turn=1.5)
+
+    assert not aircraft.on_route, "aircraft is still route following - it is orbiting the last fix"
+    assert aircraft.next_fix_index is None
+
+    # It should give up near the last fix, not part way down the approach.
+    assert Pos2D(aircraft.lat, aircraft.lon).distance(SHARP_APPROACH["END"]) < 15.0
+
+
+def test_aircraft_that_can_make_the_last_turn_still_reaches_the_fix():
+    """
+    The same approach flown with a turn radius that fits is unaffected: the aircraft reaches the fix.
+    """
+
+    # 250 kt at 6 deg/s gives a ~0.7 nmi turn radius, comfortably inside the final leg.
+    aircraft = fly(["ENTRY", "TURN", "CORNER", "END"], SHARP_APPROACH, heading=313.0, cas=250.0, rate_of_turn=6.0)
+
+    assert not aircraft.on_route
+    assert Pos2D(aircraft.lat, aircraft.lon).distance(SHARP_APPROACH["END"]) <= 2.0
+
+
+@pytest.mark.parametrize("leg_nmi", [10.0, 40.0])
+def test_straight_in_last_fix_still_uses_the_proximity_threshold(leg_nmi: float):
+    """
+    An aircraft tracking straight at its last fix ends its route within the proximity threshold, as before.
+    """
+
+    fixes = {"START": Pos2D(2.0, -2.0), "END": Pos2D(2.0 + leg_nmi / 60.0, -2.0)}
+
+    aircraft = fly(["START", "END"], fixes, heading=0.0, cas=450.0, rate_of_turn=1.5)
+
+    assert not aircraft.on_route
+    assert Pos2D(aircraft.lat, aircraft.lon).distance(fixes["END"]) <= 2.0

--- a/uv.lock
+++ b/uv.lock
@@ -8,10 +8,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [manifest]
 members = [
     "bluebird-api",
@@ -764,7 +760,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -836,7 +832,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -1114,7 +1110,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1435,17 +1431,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -1462,18 +1458,18 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
 wheels = [
@@ -1485,7 +1481,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -2855,8 +2851,8 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "types-pytz", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "types-pytz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
 wheels = [
@@ -2873,7 +2869,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/27/1d/297ff2c7ea50a768a2247621d6451abb2a07c0e9be7ca6d36ebe371658e5/pandas_stubs-3.0.0.260204.tar.gz", hash = "sha256:bf9294b76352effcffa9cb85edf0bed1339a7ec0c30b8e1ac3d66b4228f1fbc3", size = 109383, upload-time = "2026-02-04T15:17:17.247Z" }
 wheels = [
@@ -3347,7 +3343,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.11'" },
+    { name = "certifi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/10/a8480ea27ea4bbe896c168808854d00f2a9b49f95c0319ddcbba693c8a90/pyproj-3.7.1.tar.gz", hash = "sha256:60d72facd7b6b79853f19744779abcd3f804c4e0d4fa8815469db20c9f640a47", size = 226339, upload-time = "2025-02-16T04:28:46.621Z" }
 wheels = [
@@ -3395,7 +3391,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.11'" },
+    { name = "certifi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/90/67bd7260b4ea9b8b20b4f58afef6c223ecb3abf368eb4ec5bc2cdef81b49/pyproj-3.7.2.tar.gz", hash = "sha256:39a0cf1ecc7e282d1d30f36594ebd55c9fae1fda8a2622cee5d100430628f88c", size = 226279, upload-time = "2025-08-14T12:05:42.18Z" }
 wheels = [
@@ -3957,7 +3953,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -4018,7 +4014,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- stop route following once an aircraft has flown past the last fix on its route and can no longer turn back to it
- add unit tests for last-fix sequencing in the shared turn model

## Root cause

Route fixes are sequenced in `Predictor.update_position_with_turn_model`. A fix in the middle of a route is
passed once the aircraft is close enough to begin the turn onto the following leg. The target then becomes
the *next* fix, so the aircraft always moves on, however badly it flew the corner.

The last fix has nothing to sequence onto, so the only way to stop route following is to close to within
`fix_proximity_threshold`. An aircraft that cannot make the turn onto the final leg tightly enough ends up
inside its own turning circle around the fix and can never do that. Turn-rate-limited pursuit then settles
into a stable circle, and because the route turn radius is only cleared once the heading converges — which
never happens — the circle sustains itself. Nothing removes the aircraft either, since the airspace penumbra
is drawn around every named fix, destination airports included.

The result is an aircraft that circles for the remainder of the run: it clutters the display, keeps
consuming prediction time, and pollutes replay and metrics downstream. It shows up on arrival routes that
turn onto a short final leg through a large angle — a ~100° turn with about 4 nmi to run is not flyable by
an aircraft whose turn radius is 5–6 nmi.

## The fix

The last-fix branch now also ends route following once the aircraft has flown past the fix, reusing the
existing `Aircraft.distance_to_abeam` with the turn diameter as its radius:

```python
turn_radius = aircraft.predictor_params.get("turn_radius")
distance_to_abeam = (
    None if turn_radius is None else aircraft.distance_to_abeam(target_pos, radius=2 * turn_radius)
)
has_passed_fix = distance_to_abeam is not None and distance_to_abeam < 0
```

`distance_to_abeam` returns a negative distance beyond the fix, and `None` when the fix is further off track
than the turn diameter and so can still be turned back to.

This cannot fire on an approach that would have worked. An aircraft closing on a fix — tracking straight at
it or turning onto it — keeps the fix within 90° of its ground track for the whole approach, so the value
never goes negative; and an aircraft tracking straight at a fix has no route turn in progress, so
`turn_radius` is `None` and the condition is skipped entirely.

The change is in the base class, so it covers every predictor that uses the turn model, including those
defined downstream. `update_position_without_turn_model` and `RouteFollowPredictor` re-aim the heading at the
fix every step, so the distance decreases monotonically and no orbit is possible — both left alone.

## Validation

- new `tests/unit/predictor/test_predictor.py`: an aircraft with a ~4.8 nmi turn radius on a 4 nmi final leg
  orbits indefinitely without this change and stops route following with it; the same approach flown with a
  turn radius that fits still reaches the fix, and a straight-in final leg still ends at the proximity
  threshold. Speeds are pinned with `use_cas_as_tas`, so the turn radius is exact and the tests do not depend
  on performance data
- full `bluebird-dt` suite: 815 passed. The 3 failures in `tests/unit/utility/test_paths.py` are present on
  `dev` without this change (Windows user-data-dir assertions)
- regression-checked against a downstream project that consumes this package: its predictor and integration
  suites pass (440 tests), and across a batch of 18 scenarios every affected aircraft stopped orbiting while
  the remaining 642 trajectories were bit-identical
