### PR TITLE
fix: build outcomm voice phraseology correctly

### DIFF
--- a/bluebird-dt/bluebird_dt/utility/clearance.py
+++ b/bluebird-dt/bluebird_dt/utility/clearance.py
@@ -1030,16 +1030,12 @@ def voice_phraseology(action: Action, environment: Environment) -> ClearanceAndR
                 frequency_callsign = frequencies[next_sector][0]
 
                 if frequency_value[-2:] == "00":
-                    clearance_parts.extend(
-                        "contact",
-                        frequency_callsign,
-                        spell_phonetically(frequency_value[0:5]),
-                    )
+                    clearance_parts.extend(["contact", frequency_callsign, spell_phonetically(frequency_value[0:5])])
                 else:
-                    clearance_parts.extend("contact", frequency_callsign, spell_phonetically(frequency_value))
+                    clearance_parts.extend(["contact", frequency_callsign, spell_phonetically(frequency_value)])
 
             else:
-                clearance_parts.extend("contact next frequency")
+                clearance_parts.append("contact next frequency")
 
         # other actions not yet modelled. in theory, this should never be hit if the case statements above capture all
         # possible valid actions because the Action() class should prevent invalid actions from being created

--- a/bluebird-dt/tests/unit/utility/test_clearance.py
+++ b/bluebird-dt/tests/unit/utility/test_clearance.py
@@ -319,8 +319,8 @@ def test_outcomm_clearance(env: Environment):
             action,
             "AIR0 contact next frequency",
             "contact next frequency AIR0",
-            None,
-            None,
+            "alpha india romeo zero contact next frequency",
+            "contact next frequency alpha india romeo zero",
             env,
             )
 


### PR DESCRIPTION
Fixes #154

Use list-valued extend calls for frequency handoffs and append the fallback phrase atomically, preventing character-split output and latent TypeError failures. Adds an assertion for the user-visible voice outcomm result.

Tests: targeted outcomm test passed; Ruff check and format check passed for the changed implementation.

## Worked on by
- nightcityblade