### PR TITLE
fix: runner sim clock drift

### DIFF
--- a/bluebird-api/bluebird_api/routers/core.py
+++ b/bluebird-api/bluebird_api/routers/core.py
@@ -210,7 +210,7 @@ async def runner_status(runner: RunnerDep):  # noqa: ANN201
         "tick_frequency_period": runner.tick_frequency_period,
         "kill": runner.kill,
         "reload": runner.sim.manager.reload_environment if runner.sim is not None else False,
-        "time_of_next_tick": runner.time_of_next_tick.isoformat(),
+        "time_of_next_tick": datetime.fromtimestamp(runner.time_of_next_tick, timezone.utc).isoformat(),
     }
 
 

--- a/bluebird-api/bluebird_api/runner.py
+++ b/bluebird-api/bluebird_api/runner.py
@@ -19,10 +19,10 @@ a HTTP error 404 (Not found) will be returned before even running the function a
 """
 
 import asyncio
+import time
 import typing
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
 
 import typing_extensions
 from bluebird_dt.events.event_logger import SimRateUpdate
@@ -43,7 +43,7 @@ class Runner(typing.Generic[TSimulator]):
     tick_frequency_period: float = 6
     tick: int = 0
     kill: bool = False
-    time_of_next_tick: datetime = datetime.min
+    time_of_next_tick: float = 0
     hmi: defaultdict[str, HmiRunnerInformation] = field(
         default_factory=lambda: defaultdict(lambda: HmiRunnerInformation(selected_aircraft=None))
     )
@@ -69,19 +69,21 @@ class Runner(typing.Generic[TSimulator]):
         )
 
     async def run_main(self):
-        self.time_of_next_tick = datetime.now()
+        self.time_of_next_tick = time.monotonic()
 
         while True:
             if self.kill:
                 break
 
-            if self.running and datetime.now() >= self.time_of_next_tick:
-                start_time = datetime.now()
-                self.time_of_next_tick = start_time + timedelta(seconds=self.tick_frequency_period)
+            now = time.monotonic()
 
+            if self.running and now >= self.time_of_next_tick:
+                self.time_of_next_tick += self.tick_frequency_period
+                if self.time_of_next_tick < now:
+                    logger.warning(f"sim tick fell behind by {now - self.time_of_next_tick:.3f}s")
                 await self.sim.async_evolve(self.evolve_period)
                 self.tick += 1
-                logger.info(f"evolve time: {datetime.now() - start_time}")
+                logger.info(f"evolve time: {time.monotonic() - now}")
 
             await asyncio.sleep(0.1)
 

--- a/bluebird-api/tests/api/test_routes.py
+++ b/bluebird-api/tests/api/test_routes.py
@@ -209,14 +209,14 @@ class TestFunctions:
                 "tick_frequency_period": runner.tick_frequency_period,
                 "kill": runner.kill,
                 "reload": runner.sim.manager.reload_environment if runner.sim is not None else False,
-                "time_of_next_tick": runner.time_of_next_tick.isoformat(),
+                "time_of_next_tick": datetime.datetime.fromtimestamp(runner.time_of_next_tick, datetime.timezone.utc).isoformat(),
             }
 
             assert received == expected
 
             # check time of next tick separately because times will differ slightly
             received_time = datetime.datetime.fromisoformat(received["time_of_next_tick"])
-            expected_time = datetime.datetime.fromisoformat('0001-01-01T00:00:00')
+            expected_time = datetime.datetime.fromisoformat('1970-01-01T00:00:00Z')
             assert received_time - expected_time < datetime.timedelta(seconds=1)
 
     class TestScenarios:
@@ -541,4 +541,3 @@ class TestFunctions:
 
             assert received is True
             assert runner.tick_frequency_period == 243
-


### PR DESCRIPTION
This is to fix that sim clock will slowly drift with the runner if ran long enough. This was because `self.time_of_next_tick` used to reference `start_time` (`datetime.now()`) instead of from the previous scheduled tick time. Since we poll every 0.1s, `start_time` can be a bit later than `self.time_of_next_tick` was supposed to be.

This PR address this by changing to self addition `self.time_of_next_tick += self.tick_frequency_period`. In addition, moving the internal `time_of_next_tick` to `time.monotonic()` which is guaranteed to never move backward and ticks forward at a constant rate.