### PR TITLE
ci: Point dependabot to main branch

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,7 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "uv"
     directory: "/"
-    target-branch: "dev"
     versioning-strategy: "increase-if-necessary"
     schedule:
       interval: "weekly"
@@ -20,7 +19,6 @@ updates:
 
   - package-ecosystem: "npm"
     directory: "/bluebird-hmi"
-    target-branch: "dev"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
In preparation for removal of the dev branch, pointing dependabot to main.